### PR TITLE
Use more environment variables to configure the Redis client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,10 @@ Configuration
 
 You can configure the following via environment variables.
 
+`REDIS_HOST` and `REDIS_PORT` tell SnapPass how to connect to your Redis Server. Defaults to localhost on port 6379.
+
+`REDIS_DB` is the database that you want to use on that Redis server. Defaults to db 0.
+
 `SECRET_KEY` this should be a unique key that's used to sign key.  This should
 be kept secret.  See the `Flask Documentation`_ for more information.
 

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -14,7 +14,9 @@ app.config.update(
 
 id_ = lambda: uuid.uuid4().hex
 redis_host = os.environ.get('REDIS_HOST', 'localhost')
-redis_client = redis.StrictRedis(host=redis_host, port=6379, db=0)
+redis_port = int(os.environ.get('REDIS_PORT', 6379))
+redis_db = int(os.environ.get('REDIS_DB', 0))
+redis_client = redis.StrictRedis(host=redis_host, port=redis_port, db=redis_db)
 
 time_conversion = {
     'week': 604800,


### PR DESCRIPTION
SnapPass already supported the environment variable `REDIS_HOST`. This
commit adds two more variables, `REDIS_PORT` and `REDIS_DB`. They use
sensible, backwards-compatible defaults. I also added documentation in
README.rst (including the previously-undocumented `REDIS_HOST`).