### PR TITLE
Make SnapPass safer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .project
 *.rdb
 junit*xml
+*.pyc

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,5 @@
+import uuid
+
 import unittest
 from unittest import TestCase
 
@@ -54,7 +56,30 @@ class SnapPassRoutesTestCase(TestCase):
         password = "I like novelty kitten statues!"
         key = snappass.set_password(password, 30)
         rv = self.app.get('/{}'.format(key))
+        self.assertEquals(200, rv.status_code)
         self.assertIn(password, rv.data)
+
+    def test_get_unknown_key(self):
+        key = uuid.uuid4().hex
+        rv = self.app.get('/{}'.format(key))
+        self.assertEquals(404, rv.status_code)
+
+    def test_get_invalid_key(self):
+        key = "not_a_hex_string"
+        rv = self.app.get('/{}'.format(key))
+        self.assertEquals(400, rv.status_code)
+
+    def test_store_password(self):
+        form = {'password': "I like novelty sharks!", 'ttl': "hour"}
+        rv = self.app.post('/', data=form)
+        self.assertEquals(200, rv.status_code)
+        self.assertIn("Password stored", rv.data)
+
+    def test_store_lengthy_password(self):
+        password = "1234567890abcdefghijklmnopqrstuvwxyz" * 30000  # exceeds 1MB
+        form = {'password': password, 'ttl': "hour"}
+        rv = self.app.post('/', data=form)
+        self.assertEquals(400, rv.status_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Adds the prefix "snappass:" to all Redis interaction. If your Redis server is shared with other applications, this will prevent someone from using SnapPass to trawl your Redis database. *This is backwards incompatible and will break existing links.*
2. Adds validation when accepting a key, to make sure it matches the expected 32 characters of hex.
3. Adds validation when storing a password, to make sure the password isn't more than 1 MB. This will help prevent someone from using SnapPass to fill your Redis server's RAM (although it will only slow them down, not necessarily stop them).