### PR TITLE
Return the password as string instead of byte

### DIFF
--- a/snappass/main.py
+++ b/snappass/main.py
@@ -31,6 +31,8 @@ def set_password(password, ttl):
 
 def get_password(key):
     password = redis_client.get(key)
+    if password:
+        password = password.decode("utf-8")
     redis_client.delete(key)
     return password
 


### PR DESCRIPTION
`redis_client.get()` returns the password as byte, so password is printed as: **b'password'** and some people thinks that the **b''** is part of the password.

This commit ensures that the value returned by `get_password()` is a string, to be able to print the password literally as it is.

before the change:
![image](https://cloud.githubusercontent.com/assets/12781407/17526855/4609182c-5e26-11e6-942e-cd8793c0339c.png)

after the cahnge:
![image](https://cloud.githubusercontent.com/assets/12781407/17527111/4476f9e2-5e27-11e6-85e1-52448be9ca45.png)



