### PR TITLE
Prevent browser autocompletion of password

### DIFF
--- a/snappass/templates/set_password.html
+++ b/snappass/templates/set_password.html
@@ -5,7 +5,7 @@
   <section>
     <div class="page-header"><h1>Password Share</h1></div>
     <form class="form-horizontal" id="password_create" method="post">
-      <input type="text" id="password" name="password" autofocus="True" placeholder="Share a Password">
+      <input type="text" id="password" name="password" autofocus="True" placeholder="Share a Password" autocomplete="off">
       <select name="ttl">
         <option>Week</option>
         <option>Day</option>


### PR DESCRIPTION
Using the `autocomplete="off" attribute

FIxes #17 - Prevent browser autocompletion/history

Now when the field is in focus, previously entered values will not be displayed. (At least on modern browsers - tested on Safari, Chrome, Firefox)

See screenshot now:
<img width="946" alt="field_focus_after" src="https://cloud.githubusercontent.com/assets/4542383/17609825/74ce042e-6006-11e6-8857-b088794bcf5b.png">
