### PR TITLE
feature/tox_python3_support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
   - "3.5"
 sudo: false
 install:
-  - pip install tox
+  - pip install tox-travis
 script:
   - tox
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
-python: 2.7
+python:
+  - "3.5"
 sudo: false
 install:
   - pip install tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,7 +113,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7 and 3.3+. Check
+3. The pull request should work for Python 2.6, 2.7 and 3.3+. Check
    `Travis`_ and make sure that
    the tests pass for all supported Python versions.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,12 +24,6 @@ If you are reporting a bug, please include:
   as much detail as you can. Questions to start a discussion about the issue
   are welcome.
 
-Python 3.3 Support
-~~~~~~~~~~~~~~~~~~
-
-We'd love for ``tox -e py33`` to work and would welcome anybody who can help
-make that a reality.
-
 Fix Bugs
 ~~~~~~~~
 
@@ -119,7 +113,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7 and ideally 3.3. Check
+3. The pull request should work for Python 2.7 and 3.3+. Check
    `Travis`_ and make sure that
    the tests pass for all supported Python versions.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.3
+FROM python:3.5
 
 ENV APP_DIR=/usr/src/snappass
 

--- a/README.rst
+++ b/README.rst
@@ -74,4 +74,4 @@ Alternatively, you can use `Docker`_ and `Docker Compose`_ to install and run Sn
     $ docker build -t snappass .
     $ docker-compose up -d
 
-This will pull all dependencies, i.e. Redis and appropriate Python version (3.3), then start up snappass and Redis server. SnapPass server is accessible at: http://localhost:5000
+This will pull all dependencies, i.e. Redis and appropriate Python version (3.5), then start up snappass and Redis server. SnapPass server is accessible at: http://localhost:5000

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Requirements
 ------------
 
 * Redis.
-* Python 2.7 or 3.3+.
+* Python 2.6, 2.7 or 3.3+.
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Requirements
 ------------
 
 * Redis.
-* Python 2.6, 2.7 or 3.3.
+* Python 2.6, 2.7 or 3.3+.
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Requirements
 ------------
 
 * Redis.
-* Python 2.6, 2.7 or 3.3+.
+* Python 2.7 or 3.3+.
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -31,6 +31,8 @@ def set_password(password, ttl):
 
 def get_password(key):
     password = redis_client.get(key)
+    if password is not None:
+        password = password.decode('utf-8')
     redis_client.delete(key)
     return password
 

--- a/tests.py
+++ b/tests.py
@@ -58,8 +58,8 @@ class SnapPassRoutesTestCase(TestCase):
     def test_show_password(self):
         password = "I like novelty kitten statues!"
         key = snappass.set_password(password, 30)
-        rv = self.app.get('/{}'.format(key))
-        self.assertIn(password, rv.get_data(as_text=True))
+        rv = self.app.get('/{0}'.format(key))
+        self.assertTrue(password in rv.get_data(as_text=True))
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -23,6 +23,11 @@ class SnapPassTestCase(TestCase):
         # Assert that we can't look this up a second time.
         self.assertEqual(None, snappass.get_password(key))
 
+    def test_password_is_decoded(self):
+        password = "correct horse battery staple"
+        key = snappass.set_password(password, 30)
+        self.assertFalse(isinstance(snappass.get_password(key), bytes))
+
     def test_clean_input(self):
         # Test Bad Data
         with snappass.app.test_request_context(
@@ -54,7 +59,7 @@ class SnapPassRoutesTestCase(TestCase):
         password = "I like novelty kitten statues!"
         key = snappass.set_password(password, 30)
         rv = self.app.get('/{}'.format(key))
-        self.assertIn(password, rv.data)
+        self.assertIn(password, rv.get_data(as_text=True))
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27, py33, py34, py35
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 deps =


### PR DESCRIPTION
This officially adds support for python 3.3, 3.4 and 3.5 in the tests.

(CI build passed on my branch: https://travis-ci.org/samueldg/snappass/builds/151698474)

- Now the builds run in parallel for all 4 python versions, with the help of the `tox-travis`
- Implemented a fix similar to PR https://github.com/pinterest/snappass/pull/16, as the tests were failing for all python 3 versions. This also takes care of the weird b'...' passwords display.
- Bumped the python version in the Dockerfile to the latest supported.
- Updated associated docs (README, CONTRIBUTING) and pypi classifiers.