### PR TITLE
Catch Connection Error when redis isn't up #22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,3 @@ setup(
     ],
     zip_safe=False,
 )
-

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import uuid
-import traceback
 
 import redis
 from redis.exceptions import ConnectionError
@@ -29,8 +28,8 @@ def check_redis_alive(force_exit = False):
         redis_client.ping()
     except (ConnectionError, TimeoutError) as e:
         if force_exit:
-          print("{}".format(e))
-          sys.exit(0)
+            print("{}".format(e))
+            sys.exit(0)
         else:
             abort(500)
 

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -27,14 +27,15 @@ time_conversion = {
 def check_redis_alive(fn):
     def inner(*args, **kwargs):
         try:
-            redis_client.ping()
+            if fn.__name__ == 'main':
+                redis_client.ping()
+            return fn(*args, **kwargs)
         except ConnectionError as e:
-            print(e)
-            if fn.__name__ == "main":
+            print('Failed to connect to redis! %s' % e.message)
+            if fn.__name__ == 'main':
                 sys.exit(0)
             else:
                 return abort(500)
-        return fn(*args, **kwargs)
     return inner
 
 

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -3,7 +3,7 @@ import sys
 import uuid
 
 import redis
-from redis.exceptions import ConnectionError, TimeoutError
+from redis.exceptions import ConnectionError
 
 from flask import abort, Flask, render_template, request
 
@@ -28,7 +28,7 @@ def check_redis_alive(fn):
     def inner(*args, **kwargs):
         try:
             redis_client.ping()
-        except (ConnectionError, TimeoutError) as e:
+        except ConnectionError as e:
             print(e)
             if fn.__name__ == "main":
                 sys.exit(0)

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -23,12 +23,12 @@ time_conversion = {
     'hour': 3600
 }
 
-def check_redis_alive(force_exit = False):
+def check_redis_alive(force_exit=False):
     try:
         redis_client.ping()
     except (ConnectionError, TimeoutError) as e:
         if force_exit:
-            print("{}".format(e))
+            print(e)
             sys.exit(0)
         else:
             abort(500)


### PR DESCRIPTION
This handles the `ConnectionError` both when starting the server and if the redis server goes away during the request lifecycle.