### PR TITLE
inherit protocol (http/https) for stylesheet load

### DIFF
--- a/snappass/templates/base.html
+++ b/snappass/templates/base.html
@@ -4,7 +4,7 @@
   <head>
     <title>Send Password</title>
     <link href="{{ config.STATIC_URL }}/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet">
+    <link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet">
     <link href="{{ config.STATIC_URL }}/snappass/css/custom.css" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
Some browsers (e.g. latest Chrome) won't load stylesheets over http if the site is loaded over https.