### PR TITLE
Allow use of REDIS_URL env var

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,8 @@ need to change this.
 
 `SNAPPASS_REDIS_DB` is the database that you want to use on this redis server. Defaults to db 0
 
+`REDIS_URL` is optional and, if set, will be used instead of `REDIS_HOST`, `REDIS_PORT`, and `SNAPPASS_REDIS_DB` to configure the Redis client object. For example: redis://username:password@localhost:6379/0
+
 Docker
 ------
 

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -14,10 +14,14 @@ app.secret_key = os.environ.get('SECRET_KEY', 'Secret Key')
 app.config.update(
     dict(STATIC_URL=os.environ.get('STATIC_URL', 'static')))
 
-redis_host = os.environ.get('REDIS_HOST', 'localhost')
-redis_port = os.environ.get('REDIS_PORT', 6379)
-redis_db = os.environ.get('SNAPPASS_REDIS_DB', 0)
-redis_client = redis.StrictRedis(host=redis_host, port=redis_port, db=redis_db)
+if os.environ.get('REDIS_URL'):
+    redis_client = redis.StrictRedis.from_url(os.environ.get('REDIS_URL'))
+else:
+    redis_host = os.environ.get('REDIS_HOST', 'localhost')
+    redis_port = os.environ.get('REDIS_PORT', 6379)
+    redis_db = os.environ.get('SNAPPASS_REDIS_DB', 0)
+    redis_client = redis.StrictRedis(
+        host=redis_host, port=redis_port, db=redis_db)
 
 time_conversion = {
     'week': 604800,


### PR DESCRIPTION
* If present, `REDIS_URL` is used instead of `REDIS_HOST`, `REDIS_PORT`, and `SNAPPASS_REDIS_DB` to configure the Redis client object.
* Document this new env var in the README

Addresses #28 

I have used this change, [along with adding `gunicorn` to `requirements.txt` and adding a `Procfile`](https://github.com/pinterest/snappass/compare/pinterest:c22c902...dwinston:ca9474a), to successfully deploy snappass to Heroku (which supplies a `REDIS_URL` env var) for personal use. The latter changes are perhaps too specialized to warrant a PR, but I agree that handling `REDIS_URL` would be of general use.