### PR TITLE
Multiline secrets

### DIFF
--- a/snappass/templates/base.html
+++ b/snappass/templates/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Send Password</title>
+    <title>Snappass - Share Secrets</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -13,7 +13,7 @@
     <nav class="navbar navbar-default navbar-static-top">
       <div class="container">
         <div class="navbar-header">
-          <a class="navbar-brand" href="/">Share Password</a>
+          <a class="navbar-brand" href="/">Share Secret</a>
         </div>
       </div>
     </nav>

--- a/snappass/templates/confirm.html
+++ b/snappass/templates/confirm.html
@@ -3,8 +3,8 @@
 {% block content %}
 <div class="container">
   <section>
-    <div class="page-header"><h1>Share Password Link</h1></div>
-    <p>The password has been temporarily saved. Send the following URL to your intended recipient.</p>
+    <div class="page-header"><h1>Share Secret Link</h1></div>
+    <p>The secret has been temporarily saved. Send the following URL to your intended recipient.</p>
     <div class="row">
       <div class="col-sm-6 margin-bottom-10">
         <input type="text" class="form-control" id="password-link" value="{{ password_link }}" readonly="readonly">

--- a/snappass/templates/password.html
+++ b/snappass/templates/password.html
@@ -7,7 +7,7 @@
     <p>Save the following password to a secure location.</p>
     <div class="row">
       <div class="col-sm-6 margin-bottom-10">
-        <input type="text" class="form-control" id="password-text" value="{{ password }}" readonly="readonly">
+        <textarea class="form-control" rows="10" cols="50" id="password-text" name="password-text" readonly="readonly">{{ password }}</textarea>
       </div>
 
       <div class="col-sm-6">

--- a/snappass/templates/password.html
+++ b/snappass/templates/password.html
@@ -3,8 +3,8 @@
 {% block content %}
 <div class="container">
   <section>
-    <div class="page-header"><h1>Password</h1></div>
-    <p>Save the following password to a secure location.</p>
+    <div class="page-header"><h1>Secret</h1></div>
+    <p>Save the following secret to a secure location.</p>
     <div class="row">
       <div class="col-sm-6 margin-bottom-10">
         <textarea class="form-control" rows="10" cols="50" id="password-text" name="password-text" readonly="readonly">{{ password }}</textarea>
@@ -18,7 +18,7 @@
         </button>
       </div>
     </div>
-    <p>The password has now been permanently deleted from the system, and the URL will no longer work. Refresh this page to verify.</p>
+    <p>The secret has now been permanently deleted from the system, and the URL will no longer work. Refresh this page to verify.</p>
   </section>
 </div>
 {% endblock %}

--- a/snappass/templates/set_password.html
+++ b/snappass/templates/set_password.html
@@ -9,7 +9,7 @@
         <div class="col-sm-6 margin-bottom-10">
           <div class="input-group">
             <span class="input-group-addon" id="basic-addon1"><span class="glyphicon glyphicon-lock" aria-hidden="true"></span></span>
-            <input type="text" id="password" name="password" autofocus="true" class="form-control" placeholder="Password" aria-describedby="basic-addon1" autocomplete="off">
+            <textarea rows="10" cols="50" id="password" name="password" autofocus="true" class="form-control" placeholder="Password" aria-describedby="basic-addon1" autocomplete="off"></textarea>
           </div>
         </div>
 
@@ -35,7 +35,7 @@
       <li>Share the <strong>one-time use URL</strong> with your intended recipient</li>
     </ol>
 
-    </section>
+  </section>
 </div>
 {% endblock %}
 

--- a/snappass/templates/set_password.html
+++ b/snappass/templates/set_password.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container">
   <section>
-    <div class="page-header"><h1>Set Password</h1></div>
+    <div class="page-header"><h1>Set Secret</h1></div>
     <div class="row">
       <form role="form" id="password_create" method="post">
         <div class="col-sm-6 margin-bottom-10">
@@ -28,10 +28,10 @@
     </div>
 
     <h3>Using SnapPass</h3>
-    <p>SnapPass allows you to share passwords in a secure, ephemeral way.</p>
+    <p>SnapPass allows you to share secrets in a secure, ephemeral way.</p>
 
     <ol>
-      <li>Input a password, its expiration time, and click Generate URL</li>
+      <li>Input a secret, its expiration time, and click Generate URL</li>
       <li>Share the <strong>one-time use URL</strong> with your intended recipient</li>
     </ol>
 


### PR DESCRIPTION
Multiline files would get their newlines mangled in the process, making them useless.

A textarea fixes that

I would completely understand the argument: it's snappass, not snapsecret

Screenshots:
![screen shot 2017-01-05 at 11 08 12 am](https://cloud.githubusercontent.com/assets/90534/21663979/b300ab6c-d337-11e6-8761-1db8286caad0.png)
![screen shot 2017-01-05 at 11 08 44 am](https://cloud.githubusercontent.com/assets/90534/21663980/b34a6838-d337-11e6-9607-ecafde245ec7.png)
