### PR TITLE
Return 404 to UserAgents matching /bot/

### DIFF
--- a/snappass/main.py
+++ b/snappass/main.py
@@ -1,7 +1,7 @@
 import os
+import re
 import sys
 import uuid
-import re
 
 import redis
 from redis.exceptions import ConnectionError
@@ -9,6 +9,8 @@ from redis.exceptions import ConnectionError
 from flask import abort, Flask, render_template, request
 
 
+SNEAKY_USER_AGENTS = ('Slackbot', 'facebookexternalhit', 'Twitterbot', 'Facebot', 'WhatsApp')
+SNEAKY_USER_AGENTS_RE = re.compile('|'.join(SNEAKY_USER_AGENTS))
 NO_SSL = os.environ.get('NO_SSL', False)
 app = Flask(__name__)
 app.secret_key = os.environ.get('SECRET_KEY', 'Secret Key')
@@ -84,9 +86,7 @@ def request_is_valid(request):
     Ensure the request validates the following:
         - not made by some specific User-Agents (to avoid chat's preview feature issue)
     """
-    known_sneaky_user_agents = ['Slackbot', 'facebookexternalhit', 'Twitterbot', 'Facebot', 'WhatsApp']
-    user_agents_regexp = "|".join(known_sneaky_user_agents)
-    return not re.search(user_agents_regexp, request.headers.get('User-Agent', ''))
+    return not SNEAKY_USER_AGENTS_RE.search(request.headers.get('User-Agent', ''))
 
 
 @app.route('/', methods=['GET'])

--- a/tests.py
+++ b/tests.py
@@ -73,6 +73,24 @@ class SnapPassRoutesTestCase(TestCase):
         rv = self.app.get('/{0}'.format(key))
         self.assertTrue(password in rv.get_data(as_text=True))
 
+    def test_bots_denial(self):
+        """
+        Main known bots User-Agent should be denied access
+        """
+        password = "Bots can't access this"
+        key = snappass.set_password(password, 30)
+        a_few_sneaky_bots = [
+            "Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)",
+            "facebookexternalhit/1.1",
+            "Twitterbot/1.0",
+            "_WhatsApp/2.12.81 (Windows NT 6.1; U; es-ES) Presto/2.9.181 Version/12.00",
+            "WhatsApp/2.16.6/i"
+        ]
+
+        for ua in a_few_sneaky_bots:
+            rv = self.app.get('/{0}'.format(key), headers={ 'User-Agent': ua })
+            self.assertEquals(rv.status_code, 404)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -82,6 +82,7 @@ class SnapPassRoutesTestCase(TestCase):
         a_few_sneaky_bots = [
             "Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)",
             "facebookexternalhit/1.1",
+            "Facebot/1.0",
             "Twitterbot/1.0",
             "_WhatsApp/2.12.81 (Windows NT 6.1; U; es-ES) Presto/2.9.181 Version/12.00",
             "WhatsApp/2.16.6/i"


### PR DESCRIPTION
snappass links on a chat (slack.com) were not working
Their preview request was consuming the password with the following User-Agent:
```
Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)
```