### PR TITLE
Add support for python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 sudo: false
 install:
   - pip install tox-travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 
 ENV APP_DIR=/usr/src/snappass
 

--- a/README.rst
+++ b/README.rst
@@ -81,4 +81,4 @@ Alternatively, you can use `Docker`_ and `Docker Compose`_ to install and run Sn
 
     $ docker-compose up -d
 
-This will pull all dependencies, i.e. Redis and appropriate Python version (3.5), then start up snappass and Redis server. SnapPass server is accessible at: http://localhost:5000
+This will pull all dependencies, i.e. Redis and appropriate Python version (3.6), then start up snappass and Redis server. SnapPass server is accessible at: http://localhost:5000

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py26, py27, py33, py34, py35, py36
 
 [testenv]
 deps =


### PR DESCRIPTION
- Changed the Dockerfile to use `python:3.6` base image;
- Updated PyPI classifiers to include it;
- Added it to tox/travis environments for CI.