### PR TITLE
Don't allow zero length form submissions

### DIFF
--- a/snappass/main.py
+++ b/snappass/main.py
@@ -65,6 +65,9 @@ def get_password(key):
     redis_client.delete(key)
     return password
 
+def empty(value):
+    if not value:
+        return True
 
 def clean_input():
     """

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -74,6 +74,9 @@ def clean_input():
     if 'password' not in request.form:
         abort(400)
 
+    if not len(request.form['password']) > 0:
+        abort(400)
+
     if 'ttl' not in request.form:
         abort(400)
 

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -71,13 +71,10 @@ def clean_input():
     Make sure we're not getting bad data from the front end,
     format data to be machine readable
     """
-    if 'password' not in request.form:
+    if empty(request.form.get('password', '')):
         abort(400)
 
-    if not len(request.form['password']) > 0:
-        abort(400)
-
-    if 'ttl' not in request.form:
+    if empty(request.form.get('ttl', '')):
         abort(400)
 
     time_period = request.form['ttl'].lower()


### PR DESCRIPTION
Currently the web form allows someone to submit a zero length secret/password even though redis does not actually store anything; the resulting URL will 404.

This is a quick fix to throw a Bad Request if someone submits the form without inputting anything.

I haven't added any tests as I already see tests to check this exact issue using POST commands - which must have been passing. The current tests look more suited to test an API instead of a web form. Do they need to be refactored?