### PR TITLE
Move brief documentation to textarea

### DIFF
--- a/snappass/templates/set_password.html
+++ b/snappass/templates/set_password.html
@@ -9,7 +9,7 @@
         <div class="col-sm-6 margin-bottom-10">
           <div class="input-group">
             <span class="input-group-addon" id="basic-addon1"><span class="glyphicon glyphicon-lock" aria-hidden="true"></span></span>
-            <textarea rows="10" cols="50" id="password" name="password" autofocus="true" class="form-control" placeholder="Password" aria-describedby="basic-addon1" autocomplete="off"></textarea>
+            <textarea rows="10" cols="50" id="password" name="password" autofocus="true" class="form-control" placeholder="SnapPass allows you to share secrets in a secure, ephemeral way. Input a single or multi-line secret, its expiration time, and click Generate URL. Share the one-time use URL with your intended recipient." aria-describedby="basic-addon1" autocomplete="off"></textarea>
           </div>
         </div>
 
@@ -26,15 +26,6 @@
         </div>
       </form>
     </div>
-
-    <h3>Using SnapPass</h3>
-    <p>SnapPass allows you to share secrets in a secure, ephemeral way.</p>
-
-    <ol>
-      <li>Input a secret, its expiration time, and click Generate URL</li>
-      <li>Share the <strong>one-time use URL</strong> with your intended recipient</li>
-    </ol>
-
   </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
Moved the brief front page documentation to placeholder text in the textarea. Makes everything look super clean and puts the documentation front and center on mobile screens.