### PR TITLE
Bump version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 1.0.0
 commit = False
-tag = True
+tag = False
 
 [flake8]
 show-source = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 current_version = 1.0.0
 commit = False
 tag = False
+files = setup.py snappass/__init__.py
 
 [flake8]
 show-source = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
-current_version = 1.0.0
-commit = False
-tag = False
+current_version = 1.1.0
+commit = True
+tag = True
 files = setup.py snappass/__init__.py
 
 [flake8]
@@ -9,3 +9,4 @@ show-source = True
 max-line-length = 120
 
 [bumpversion:file:snappass/__init__.py]
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='snappass',
-    version='0.1.0',
+    version='1.0.0',
     description="It's like SnapChat... for Passwords.",
     long_description=(open('README.rst').read() + '\n\n' +
                       open('AUTHORS.rst').read()),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='snappass',
-    version='1.0.0',
+    version='1.1.0',
     description="It's like SnapChat... for Passwords.",
     long_description=(open('README.rst').read() + '\n\n' +
                       open('AUTHORS.rst').read()),

--- a/snappass/__init__.py
+++ b/snappass/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'davedash'
-__version__ = '1.0.0'
+__version__ = '1.1.0'


### PR DESCRIPTION
As described in the wiki of the project, this new config allows us to bump the version using [bumpversion](https://github.com/peritus/bumpversion).

New command is now very simple:
```bash
bumpversion --config-file setup.cfg minor
```