### PR TITLE
Docs/pypi badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,11 @@
 SnapPass
 ========
 
-.. image:: https://travis-ci.org/pinterest/snappass.svg
+|build|
 
+.. |build| image:: https://travis-ci.org/pinterest/snappass.svg
+    :target: http://travis-ci.org/pinterest/snappass
+    :alt: Build status
 
 It's like SnapChat... for Passwords.
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,11 @@
 SnapPass
 ========
 
-|build|
+|pypi| |build|
+
+.. |pypi| image:: https://img.shields.io/pypi/v/snappass.svg
+    :target: https://pypi.python.org/pypi/snappass
+    :alt: Latest version released on PyPI
 
 .. |build| image:: https://travis-ci.org/pinterest/snappass.svg
     :target: http://travis-ci.org/pinterest/snappass


### PR DESCRIPTION
Add a badge for PyPI package, which will display the current version.

And improve existing one to point to the right Travis page.

Looks like this:

<img width="475" alt="pypi-badge" src="https://cloud.githubusercontent.com/assets/4542383/25568088/8f19ea3c-2dc9-11e7-9883-55d7f3e49574.png">
