### PR TITLE
Feature/secure password storage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ trouble of writing it yourself, because maybe you are busy and have other things
 to do.  Enjoy.
 
 Security
-~~~~~~~~
+--------
 
 Passwords are encrypted using `Fernet`_ symmetric encryption, from the `cryptography`_ library.
 A random unique key is generated for each password, and is never stored;

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,17 @@ Anyway, this took us very little time to write, but we figure we'd save you the
 trouble of writing it yourself, because maybe you are busy and have other things
 to do.  Enjoy.
 
+Security
+~~~~~~~~
+
+Passwords are encrypted using `Fernet`_ symmetric encryption, from the `cryptography`_ library.
+A random unique key is generated for each password, and is never stored;
+it is rather sent as part of the password link.
+This means that even if someone has access to the Redis store, the passwords are still safe.
+
+.. _Fernet: https://cryptography.io/en/latest/fernet/
+.. _cryptography: https://cryptography.io/en/latest/
+
 Requirements
 ------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ MarkupSafe==0.18
 Werkzeug==0.9.4
 itsdangerous==0.23
 redis==2.8.0
+cryptography==1.8.1

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -4,11 +4,10 @@ import sys
 import uuid
 
 import redis
-from redis.exceptions import ConnectionError
-
-from flask import abort, Flask, render_template, request
 
 from cryptography.fernet import Fernet
+from flask import abort, Flask, render_template, request
+from redis.exceptions import ConnectionError
 
 
 SNEAKY_USER_AGENTS = ('Slackbot', 'facebookexternalhit', 'Twitterbot',

--- a/tests.py
+++ b/tests.py
@@ -124,7 +124,7 @@ class SnapPassRoutesTestCase(TestCase):
 
         for ua in a_few_sneaky_bots:
             rv = self.app.get('/{0}'.format(key), headers={ 'User-Agent': ua })
-            self.assertEquals(rv.status_code, 404)
+            self.assertEqual(rv.status_code, 404)
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,9 @@
 import time
 import unittest
+import uuid
 from unittest import TestCase
 
+from cryptography.fernet import Fernet
 from werkzeug.exceptions import BadRequest
 
 # noinspection PyPep8Naming
@@ -12,17 +14,48 @@ __author__ = 'davedash'
 
 class SnapPassTestCase(TestCase):
 
-    def test_set_password(self):
-        """Ensure we return a 32-bit key."""
-        key = snappass.set_password("foo", 30)
-        self.assertEqual(32, len(key))
-
     def test_get_password(self):
         password = "melatonin overdose 1337!$"
         key = snappass.set_password(password, 30)
         self.assertEqual(password, snappass.get_password(key))
         # Assert that we can't look this up a second time.
         self.assertEqual(None, snappass.get_password(key))
+
+    def test_password_is_not_stored_in_plaintext(self):
+        password = "trustno1"
+        token = snappass.set_password(password, 30)
+        redis_key = token.split(snappass.TOKEN_SEPARATOR)[0]
+        stored_password_text = snappass.redis_client.get(redis_key).decode('utf-8')
+        self.assertFalse(password in stored_password_text)
+
+    def test_returned_token_format(self):
+        password = "trustsome1"
+        token = snappass.set_password(password, 30)
+        token_fragments = token.split(snappass.TOKEN_SEPARATOR)
+        self.assertEqual(2, len(token_fragments))
+        redis_key, encryption_key = token_fragments
+        self.assertEqual(32, len(redis_key))
+        try:
+            Fernet(encryption_key.encode('utf-8'))
+        except ValueError:
+            self.fail('the encryption key is not valid')
+
+    def test_encryption_key_is_returned(self):
+        password = "trustany1"
+        token = snappass.set_password(password, 30)
+        token_fragments = token.split(snappass.TOKEN_SEPARATOR)
+        redis_key, encryption_key = token_fragments
+        stored_password = snappass.redis_client.get(redis_key)
+        fernet = Fernet(encryption_key.encode('utf-8'))
+        decrypted_password = fernet.decrypt(stored_password).decode('utf-8')
+        self.assertEqual(password, decrypted_password)
+
+    def test_unencrypted_passwords_still_work(self):
+        unencrypted_password = "trustevery1"
+        storage_key = uuid.uuid4().hex
+        snappass.redis_client.setex(storage_key, 30, unencrypted_password)
+        retrieved_password = snappass.get_password(storage_key)
+        self.assertEqual(unencrypted_password, retrieved_password)
 
     def test_password_is_decoded(self):
         password = "correct horse battery staple"


### PR DESCRIPTION
Encrypt secrets before saving them in Redis.

Using symmetric encryption in the `cryptography`'s `Fernet` class,
we can ensure that no one can snoop the passwords simply by having access
to Redis instance.

Along with the 32-character Redis key that identifies the secret,
an encryption key is now sent, which is needed to decrypt the password.

Closes #63 

See the issue for a detailed discussion/explanation.
Thanks to @nichochar @0x0ece and @devinlundberg for the feedback on the proposal!

### Note

The tilde ('~') was chosen as a separator because:
- it's an unreserved URL character [1] (so you can pass the URL around more easily, without escaping) 
- it won't conflict with the generated uuid or encryption key.


