### PR TITLE
Add cryptography in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     long_description=(open('README.rst').read() + '\n\n' +
                       open('AUTHORS.rst').read()),
     url='http://github.com/Pinterest/snappass/',
-    install_requires=['Flask', 'redis'],
+    install_requires=['Flask', 'redis', 'cryptography'],
     license='MIT',
     author='Dave Dash',
     author_email='dd+github@davedash.com',


### PR DESCRIPTION
This fixes the Docker image, which relies on `python setup.py install` rather than `pip install requirements.txt` to get the requirements.

Since `cryptography` had been added (my bad) to `requirements.txt` but not `setup.py`, the local installation would work but not the Docker one.

This is a hotfix though, I think the best solution would be to align both files, to avoid mismatches, as well as version issues (`setup.py` does not pin specific versions.)