### PR TITLE
Send sigint signal to properly shutdown flask

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
         image: pinterest/snappass
         ports:
             - "5000:5000"
+        stop_signal: SIGINT
         environment:
             - REDIS_HOST=redis
             - NO_SSL=True


### PR DESCRIPTION
By default, docker stop command sends a SIGTERM to the root process. But this signal is ignored by flask. This results in a forced KILL 10 seconds later. [->ref](https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/)

Changing the stop signal from SIGTERM to SIGINT (=CTRL-C) in the compose file allows for a faster and more graceful shutdown of flask.