### PR TITLE
add  host_name env variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,8 @@ need to change this.
 
 `NO_SSL` if you are not using SSL.
 
+`HOST_NAME` this is display as a link for new passwords. Defaults to `"http[s]://localhost/"`
+
 `REDIS_HOST` this should be set by Redis, but you can override it if you want. Defaults to `"localhost"`
 
 `REDIS_PORT` is the port redis is serving on, defaults to 6379

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -15,6 +15,7 @@ SNEAKY_USER_AGENTS = ('Slackbot', 'facebookexternalhit', 'Twitterbot',
                       'Iframely')
 SNEAKY_USER_AGENTS_RE = re.compile('|'.join(SNEAKY_USER_AGENTS))
 NO_SSL = os.environ.get('NO_SSL', False)
+HOST_NAME = os.environ.get('HOST_NAME', False)
 TOKEN_SEPARATOR = '~'
 
 
@@ -161,10 +162,13 @@ def handle_password():
     ttl, password = clean_input()
     token = set_password(password, ttl)
 
-    if NO_SSL:
-        base_url = request.url_root
+    if HOST_NAME:
+        base_url = HOST_NAME
     else:
-        base_url = request.url_root.replace("http://", "https://")
+        if NO_SSL:
+            base_url = request.url_root
+        else:
+            base_url = request.url_root.replace("http://", "https://")
     link = base_url + token
     return render_template('confirm.html', password_link=link)
 


### PR DESCRIPTION
When running this behind a reverse -proxy the `base_url` is always
`localhost:port`. But usually Nginx provides this under another URL.