### PR TITLE
Enhancement/modernize tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -22,14 +22,14 @@ class SnapPassTestCase(TestCase):
         key = snappass.set_password(password, 30)
         self.assertEqual(password, snappass.get_password(key))
         # Assert that we can't look this up a second time.
-        self.assertEqual(None, snappass.get_password(key))
+        self.assertIsNone(snappass.get_password(key))
 
     def test_password_is_not_stored_in_plaintext(self):
         password = "trustno1"
         token = snappass.set_password(password, 30)
         redis_key = token.split(snappass.TOKEN_SEPARATOR)[0]
         stored_password_text = snappass.redis_client.get(redis_key).decode('utf-8')
-        self.assertFalse(password in stored_password_text)
+        self.assertNotIn(password, stored_password_text)
 
     def test_returned_token_format(self):
         password = "trustsome1"
@@ -97,7 +97,7 @@ class SnapPassTestCase(TestCase):
         # Expire functionality must be explicitly invoked using do_expire(time).
         # mockredis does not support automatic expiration at this time
         snappass.redis_client.do_expire()
-        self.assertEqual(None, snappass.get_password(key))
+        self.assertIsNone(snappass.get_password(key))
 
 
 class SnapPassRoutesTestCase(TestCase):
@@ -110,7 +110,7 @@ class SnapPassRoutesTestCase(TestCase):
         password = "I like novelty kitten statues!"
         key = snappass.set_password(password, 30)
         rv = self.app.get('/{0}'.format(key))
-        self.assertTrue(password in rv.get_data(as_text=True))
+        self.assertIn(password, rv.get_data(as_text=True))
 
     def test_bots_denial(self):
         """

--- a/tests.py
+++ b/tests.py
@@ -131,7 +131,7 @@ class SnapPassRoutesTestCase(TestCase):
 
         for ua in a_few_sneaky_bots:
             rv = self.app.get('/{0}'.format(key), headers={ 'User-Agent': ua })
-            self.assertEqual(rv.status_code, 404)
+            self.assertEqual(404, rv.status_code)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ setenv =
 commands =
     pip install -r requirements.txt
     pip install -r dev-requirements.txt
-    py.test --junitxml=junit-{envname}.xml --cov-report xml tests.py
+    pytest --junitxml=junit-{envname}.xml --cov-report xml tests.py
 
 [testenv:flake8]
 commands =


### PR DESCRIPTION
As promised in https://github.com/pinterest/snappass/issues/76, some enhancements possible now that Python 2.6 compatibility isn't required.

Also:
* fixed an inconsistent `assertEqual`ordering;
* changed `py.test` to `pytest`.

Fun fact, there is a [#DropTheDot](https://twitter.com/hashtag/dropthedot) hashtag dedicated to this...