### PR TITLE
Add prefix to redis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Configuration
 
 You can configure the following via environment variables.
 
-`SECRET_KEY` this should be a unique key that's used to sign key.  This should
+`SECRET_KEY` unique key that's used to sign key. This should
 be kept secret.  See the `Flask Documentation`__ for more information.
 
 .. __: http://flask.pocoo.org/docs/quickstart/#sessions
@@ -88,7 +88,9 @@ need to change this.
 
 `SNAPPASS_REDIS_DB` is the database that you want to use on this redis server. Defaults to db 0
 
-`REDIS_URL` is optional and, if set, will be used instead of `REDIS_HOST`, `REDIS_PORT`, and `SNAPPASS_REDIS_DB` to configure the Redis client object. For example: redis://username:password@localhost:6379/0
+`REDIS_URL` (optional) will be used instead of `REDIS_HOST`, `REDIS_PORT`, and `SNAPPASS_REDIS_DB` to configure the Redis client object. For example: redis://username:password@localhost:6379/0
+
+`REDIS_PREFIX` (optional, defaults to `"snappass"`) prefix used on redis keys to prevent collisions with other potential clients
 
 Docker
 ------

--- a/tests.py
+++ b/tests.py
@@ -37,7 +37,7 @@ class SnapPassTestCase(TestCase):
         token_fragments = token.split(snappass.TOKEN_SEPARATOR)
         self.assertEqual(2, len(token_fragments))
         redis_key, encryption_key = token_fragments
-        self.assertEqual(32, len(redis_key))
+        self.assertEqual(32 + len(snappass.REDIS_PREFIX), len(redis_key))
         try:
             Fernet(encryption_key.encode('utf-8'))
         except ValueError:
@@ -130,7 +130,7 @@ class SnapPassRoutesTestCase(TestCase):
         ]
 
         for ua in a_few_sneaky_bots:
-            rv = self.app.get('/{0}'.format(key), headers={ 'User-Agent': ua })
+            rv = self.app.get('/{0}'.format(key), headers={'User-Agent': ua})
             self.assertEqual(404, rv.status_code)
 
 


### PR DESCRIPTION
Fixes #32

Small improvement adding a prefix to the `uuid.uuid4().hex` we use as the key to store the passwords. This can prevent collisions if redis is being used by multiple clients.

It's also possible to configure this value with the `REDIS_PREFIX` env variable, for which I added documentation in the README