### PR TITLE
Feature/support python37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 sudo: false
 install:
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+  # - "3.7"  # TODO: Re-enable after https://github.com/travis-ci/travis-ci/issues/9815 is fixed
 sudo: false
 install:
   - pip install tox-travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7-slim
 
 ENV APP_DIR=/usr/src/snappass
 

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Alternatively, you can use `Docker`_ and `Docker Compose`_ to install and run Sn
 
     $ docker-compose up -d
 
-This will pull all dependencies, i.e. Redis and appropriate Python version (3.6), then start up SnapPass and Redis server. SnapPass server is accessible at: http://localhost:5000
+This will pull all dependencies, i.e. Redis and appropriate Python version (3.7), then start up SnapPass and Redis server. SnapPass server is accessible at: http://localhost:5000
 
 We're Hiring!
 -------------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-pytest==3.5.1
+pytest==3.6.3
 pytest-cov==2.5.1
 mockredispy==2.9.3
-coverage==4.2
-flake8==3.0.4
-tox==3.0.0
+coverage==4.5.1
+flake8==3.5.0
+tox==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Flask==0.11.1
-Jinja2==2.7.1
-MarkupSafe==0.18
-Werkzeug==0.9.4
-itsdangerous==0.23
-redis==2.8.0
-cryptography==1.8.1
-mock==1.0.1
+Flask==1.0.2
+Jinja2==2.10
+MarkupSafe==1.0
+Werkzeug==0.14.1
+itsdangerous==0.24
+redis==2.10.6
+cryptography==2.2.2
+mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py27, py34, py35, py36, py37, flake8
 
 [testenv]
 setenv = 


### PR DESCRIPTION
Add support for Python 3.7

* Updated all PyPI dependencies (`requirements` and `dev-requirements`) to latest stable
* Added Python 3.7 in tested versions (tox and Travis CI)
* Updated base Docker image to python:3.7-slim
   * Takes the base image size from 916MB down to 143MB!

⚠️ Currently this will fail because of: https://github.com/travis-ci/travis-ci/issues/9815 ⚠️ 
Wanted to submit regardless to see if there's interest in merging this eventually.