### PR TITLE
Add support for Cloud Foundry

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: env FLASK_APP=snappass.main flask run --host=0.0.0.0 --port=$PORT

--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,20 @@ Alternatively, you can use `Docker`_ and `Docker Compose`_ to install and run Sn
 
 This will pull all dependencies, i.e. Redis and appropriate Python version (3.7), then start up SnapPass and Redis server. SnapPass server is accessible at: http://localhost:5000
 
+Cloud Foundry
+-------------
+
+Modify the example ``manifest.yml`` to match your own requirements, and then
+push the app to Cloud Foundry with ``cf push``. For more control, see the
+complete list of available properties in the documentation for manifests_.
+
+.. _manifests: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html
+
+If you want to pin a specific Python version, then add a ``runtime.txt`` file
+as `explained in the documentation`_.
+
+.. __: https://docs.cloudfoundry.org/buildpacks/python/index.html#runtime
+
 We're Hiring!
 -------------
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,14 @@
+applications:
+- name: snappass
+  path: .
+  memory: 128M
+  disk_quota: 256M
+  instances: 1
+  host: snappass
+  timeout: 180
+  buildpack: python_buildpack
+  env:
+    SECRET_KEY: "<put-here-something-random-like-32-characters-long>" # See: http://flask.pocoo.org/docs/1.0/quickstart/#sessions
+
+  services:
+    - snappass-db # some redis instance

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -33,6 +33,13 @@ if os.environ.get('MOCK_REDIS'):
     redis_client = mock_strict_redis_client()
 elif os.environ.get('REDIS_URL'):
     redis_client = redis.StrictRedis.from_url(os.environ.get('REDIS_URL'))
+elif os.environ.get('VCAP_SERVICES'):
+    import json
+    vcap_services = json.loads(os.environ.get('VCAP_SERVICES'))
+    redis_instance = vcap_services['redis'][0]['credentials']
+    redis_client = redis.StrictRedis(
+        host=redis_instance['host'], port=redis_instance['port'],
+        password=redis_instance['password'])
 else:
     redis_host = os.environ.get('REDIS_HOST', 'localhost')
     redis_port = os.environ.get('REDIS_PORT', 6379)


### PR DESCRIPTION
Hi,

Here are small contributions that allows snappass to be pushed to Cloud Foundry easily.

Here we add the necessary `Procfile`, an example manifest, and in the code, support for the  `VCAP_SERVICES` environment variable that holds parameters to the bound redis instance.

I also added some words in the README so that users can know what they can do with it.

Best