### PR TITLE
Upgrade to cryptography 2.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+Version 1.4.1
+-------------
+ * Upgraded cryptography to 2.3.1 (for CVE-2018-10903, although snappass is
+   unaffected because it doesn't use the vulnerable ``finalize_with_tag`` API)
+
 Version 1.4.0
 -------------
 *You will lose stored passwords during the upgrade to this version*

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ MarkupSafe==1.0
 Werkzeug==0.14.1
 itsdangerous==0.24
 redis==2.10.6
-cryptography==2.2.2
+cryptography==2.3.1
 mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='snappass',
-    version='1.4.0',
+    version='1.4.1',
     description="It's like SnapChat... for Passwords.",
     long_description=(open('README.rst').read() + '\n\n' +
                       open('AUTHORS.rst').read()),


### PR DESCRIPTION
This addresses CVE-2018-10903:

    A flaw was found in python-cryptography versions between >=1.9.0 and
    <2.3. The finalize_with_tag API did not enforce a minimum tag
    length. If a user did not validate the input length prior to passing
    it to finalize_with_tag an attacker could craft an invalid payload
    with a shortened tag (e.g. 1 byte) such that they would have a 1 in
    256 chance of passing the MAC check. GCM tag forgeries can cause key
    leakage.

... although snappass isn't affected because we doesn't use the
vulnerable `finalize_with_tag` API.