### PR TITLE
Build on Python 3.7 and cache pip artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - "master"
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  # - "3.7"  # TODO: Re-enable after https://github.com/travis-ci/travis-ci/issues/9815 is fixed
-sudo: false
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+cache: pip
 install:
   - pip install tox-travis
 script:


### PR DESCRIPTION
This uses the well-established workaround to get Python 3.7 working on
Travis.