### PR TITLE
Upgrade to Jinja2 2.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.0.2
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.0
 Werkzeug==0.14.1
 itsdangerous==0.24


### PR DESCRIPTION
This patch release fixes a security issue (CVE-2019-10906) involving
str.format_map.