### PR TITLE
Set autocomplete=off on form to avoid back history; make textarea field required

### DIFF
--- a/snappass/templates/set_password.html
+++ b/snappass/templates/set_password.html
@@ -5,11 +5,11 @@
   <section>
     <div class="page-header"><h1>Set Secret</h1></div>
     <div class="row">
-      <form role="form" id="password_create" method="post">
+      <form role="form" id="password_create" method="post" autocomplete="off">
         <div class="col-sm-6 margin-bottom-10">
           <div class="input-group">
             <span class="input-group-addon" id="basic-addon1"><span class="glyphicon glyphicon-lock" aria-hidden="true"></span></span>
-            <textarea rows="10" cols="50" id="password" name="password" autofocus="true" class="form-control" placeholder="SnapPass allows you to share secrets in a secure, ephemeral way. Input a single or multi-line secret, its expiration time, and click Generate URL. Share the one-time use URL with your intended recipient." aria-describedby="basic-addon1" autocomplete="off"></textarea>
+            <textarea rows="10" cols="50" id="password" name="password" autofocus="true" class="form-control" placeholder="SnapPass allows you to share secrets in a secure, ephemeral way. Input a single or multi-line secret, its expiration time, and click Generate URL. Share the one-time use URL with your intended recipient." aria-describedby="basic-addon1" autocomplete="off" required></textarea>
           </div>
         </div>
 


### PR DESCRIPTION
This solves 1) and 3) from #102 (thanks for reporting @bensharp1!).

I was able to reproduce the issues locally and confirm that this code change fixes both.

I didn't put in the fix for 2) because it seemed like less of an issue for me., since the person creating the link is typically not malicious, so generating multiple URLs doesn't seem like an issue, and I'd rather have as little JS as possible.