### PR TITLE
Add url prefix for reverse proxies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,8 @@ need to change this.
 
 ``NO_SSL``: if you are not using SSL.
 
+``URL_PREFIX``: useful when running snappass behind a reverse proxy like `nginx`. Example: ``"/some/path/"``, Defaults to ``None``
+
 ``REDIS_HOST``: this should be set by Redis, but you can override it if you want. Defaults to ``"localhost"``
 
 ``REDIS_PORT``: is the port redis is serving on, defaults to 6379

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -12,6 +12,7 @@ from werkzeug.urls import url_quote_plus
 from werkzeug.urls import url_unquote_plus
 
 NO_SSL = os.environ.get('NO_SSL', False)
+URL_PREFIX = os.environ.get('URL_PREFIX', None)
 TOKEN_SEPARATOR = '~'
 
 
@@ -165,6 +166,8 @@ def handle_password():
         base_url = request.url_root
     else:
         base_url = request.url_root.replace("http://", "https://")
+    if URL_PREFIX:
+        base_url = base_url + URL_PREFIX.strip("/") + "/"
     link = base_url + url_quote_plus(token)
     return render_template('confirm.html', password_link=link)
 

--- a/tests.py
+++ b/tests.py
@@ -115,6 +115,11 @@ class SnapPassRoutesTestCase(TestCase):
         rv = self.app.post('/{0}'.format(key))
         self.assertIn(password, rv.get_data(as_text=True))
 
+    def test_url_prefix(self):
+        password = "I like novelty kitten statues!"
+        snappass.URL_PREFIX="/test/prefix"
+        rv = self.app.post('/', data={'password': password, 'ttl': 'hour'})
+        self.assertIn("localhost/test/prefix/", rv.get_data(as_text=True))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Thanks for this concise and useful project :)

In a reverse proxy setup, it would be useful to allow a prefix / context-path to be used while generating the secret URL. I have added an environment variable to support this.

I am tempted to use `APPLICATION_ROOT` or a [blueprint](https://flask.palletsprojects.com/en/1.1.x/blueprints/) but with a limited use case like in this case I am not sure if that really would make sense.  Please review. 