### PR TITLE
Migrate to fakeredis from mockredispy

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 pytest==3.6.3
 pytest-cov==2.5.1
-mockredispy==2.9.3
+fakeredis==0.7.0
 coverage==4.5.1
 flake8==3.5.0
 tox==3.1.2

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -25,8 +25,8 @@ app.config.update(
 
 # Initialize Redis
 if os.environ.get('MOCK_REDIS'):
-    from mockredis import mock_strict_redis_client
-    redis_client = mock_strict_redis_client()
+    from fakeredis import FakeStrictRedis
+    redis_client = FakeStrictRedis()
 elif os.environ.get('REDIS_URL'):
     redis_client = redis.StrictRedis.from_url(os.environ.get('REDIS_URL'))
 else:

--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from cryptography.fernet import Fernet
 from werkzeug.exceptions import BadRequest
-from mockredis import mock_strict_redis_client
+from fakeredis import FakeStrictRedis
 
 # noinspection PyPep8Naming
 import snappass.main as snappass
@@ -16,7 +16,7 @@ __author__ = 'davedash'
 
 class SnapPassTestCase(TestCase):
 
-    @patch('redis.client.StrictRedis', mock_strict_redis_client)
+    @patch('redis.client.StrictRedis', FakeStrictRedis)
     def test_get_password(self):
         password = "melatonin overdose 1337!$"
         key = snappass.set_password(password, 30)
@@ -94,9 +94,6 @@ class SnapPassTestCase(TestCase):
         password = 'open sesame'
         key = snappass.set_password(password, 1)
         time.sleep(1.5)
-        # Expire functionality must be explicitly invoked using do_expire(time).
-        # mockredis does not support automatic expiration at this time
-        snappass.redis_client.do_expire()
         self.assertIsNone(snappass.get_password(key))
 
 


### PR DESCRIPTION
Addresses https://github.com/pinterest/snappass/issues/107
I have also removed `do_expire` as `fakeredis` does support expiration so it does not need to be manually invoked.

ping @jparise 
