### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+  - "3.7"
 cache: pip
 install:
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 cache: pip
 install:
   - pip install tox-travis

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Version 1.5.0 (in development)
 * The ``URL_PREFIX`` environment variable can be used to add a prefix to URLs,
   which is useful when running behind a reverse proxy like nginx.
 * Replaced mockredis with fakeredis in the unit test environment.
+* Added support for Python 3.8.
 
 Version 1.4.2
 -------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 ENV APP_DIR=/usr/src/snappass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.0.2
 Jinja2==2.10.1
 MarkupSafe==1.0
-Werkzeug==0.15.3
+Werkzeug==0.15.6
 itsdangerous==0.24
 redis==2.10.6
 cryptography==2.3.1

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         ],
     },
     include_package_data=True,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, flake8
+envlist = py27, py34, py35, py36, py37, py38, flake8
 
 [testenv]
 setenv = 


### PR DESCRIPTION
* Add Python 3.8 to tox and Travis to ensure it's tested
* Update `setup.py` classifiers to include 3.8
    - Also add the more explicit `python_requires` field
* Bump Docker image to 3.8
* Minor `werkzeug` bump (see 91214ca for rationale)