### PR TITLE
Use 'six' to import 'unquote'

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -4,12 +4,12 @@ import time
 import unittest
 import uuid
 from unittest import TestCase
-from urllib.parse import unquote
 
 from cryptography.fernet import Fernet
 from freezegun import freeze_time
 from werkzeug.exceptions import BadRequest
 from fakeredis import FakeStrictRedis
+from six.moves.urllib.parse import unquote
 
 # noinspection PyPep8Naming
 import snappass.main as snappass


### PR DESCRIPTION
This maintains compatibility with Python 2.7.