### PR TITLE
Moved setuptools to develop mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR $APP_DIR
 COPY ["setup.py", "MANIFEST.in", "README.rst", "AUTHORS.rst", "$APP_DIR/"]
 COPY ["./snappass", "$APP_DIR/snappass"]
 
-RUN python setup.py install && \
+RUN python setup.py develop && \
     chown -R snappass $APP_DIR && \
     chgrp -R snappass $APP_DIR
 


### PR DESCRIPTION
I think the package should be installed in dev mode otherwise the Flask app runs from site-packages and container user is not authorized to open file there.