### PR TITLE
Adds environment variable to replace host on the Share Secret Link page.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,8 @@ be kept secret.  See the `Flask Documentation`__ for more information.
 ``STATIC_URL``: this should be the location of your static assets.  You might not
 need to change this.
 
+``HOST``: allows you to overwrite the host displayed on the Share Secret Link page. Example: ``example.org``.  
+
 ``NO_SSL``: if you are not using SSL.
 
 ``URL_PREFIX``: useful when running snappass behind a reverse proxy like `nginx`. Example: ``"/some/path/"``, Defaults to ``None``

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -13,6 +13,7 @@ from distutils.util import strtobool
 
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
 URL_PREFIX = os.environ.get('URL_PREFIX', None)
+HOST = os.environ.get('HOST', None)
 TOKEN_SEPARATOR = '~'
 
 
@@ -163,10 +164,14 @@ def handle_password():
     ttl, password = clean_input()
     token = set_password(password, ttl)
 
-    if NO_SSL:
-        base_url = request.url_root
+    if HOST:
+        base_url = "http://" + HOST + '/'
     else:
-        base_url = request.url_root.replace("http://", "https://")
+        base_url = request.url_root
+    if NO_SSL:
+        base_url = base_url
+    else:
+        base_url = base_url.replace("http://", "https://")
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
     link = base_url + url_quote_plus(token)


### PR DESCRIPTION
Updated main.py and README.rst. HOST environment variable can be used to replace the host on the Share Secret Link page.