### PR TITLE
Allowing full host override

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ need to change this.
 
 ``REDIS_PREFIX``: (optional, defaults to ``"snappass"``) prefix used on redis keys to prevent collisions with other potential clients
 
-``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity aware SSO. Example: sub.domain.com
+``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
 Docker
 ------

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,8 @@ need to change this.
 
 ``REDIS_PREFIX``: (optional, defaults to ``"snappass"``) prefix used on redis keys to prevent collisions with other potential clients
 
+``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity aware SSO. Example: sub.domain.com
+
 Docker
 ------
 

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -13,6 +13,7 @@ from distutils.util import strtobool
 
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
 URL_PREFIX = os.environ.get('URL_PREFIX', None)
+HOST_OVERRIDE = os.environ.get('HOST_OVERRIDE', None)
 TOKEN_SEPARATOR = '~'
 
 
@@ -164,9 +165,15 @@ def handle_password():
     token = set_password(password, ttl)
 
     if NO_SSL:
-        base_url = request.url_root
+        if HOST_OVERRIDE:
+            base_url = f'http://{HOST_OVERRIDE}/'
+        else:
+            base_url = request.url_root
     else:
-        base_url = request.url_root.replace("http://", "https://")
+        if HOST_OVERRIDE:
+            base_url = f'https://{HOST_OVERRIDE}/'
+        else:
+            base_url = request.url_root.replace("http://", "https://")
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
     link = base_url + url_quote_plus(token)


### PR DESCRIPTION
A small addition I've implemented on our end. 
This is useful when running behind a proxy where the app is not aware of it's external URL.
So instead of using and IP, or a private un-reachable address, this allows a full path overriding and works like a charm even when the app is running in an internal environment!