### PR TITLE
Publishing docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,35 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64 # available arch : linux/amd64,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/snappass:latest
+  


### PR DESCRIPTION
Hey everyone,

This proposal simply uses github actions to build the docker image and push it to dockerhub for arm64 and amd64 architectures when someone push something to master.      
I've written this for myself as i wanted to run this project on a Raspberry pi v3 Model B so a docker image for the architecture arm64 was needed and the only official image I found (https://github.com/pinterest/snappass/pkgs/container/snappass%2Fsnappass/versions) wasn't suitable for my arch.
I think having an official build on dockerhub could please any user of this project :)


When merging this, you should create a dockerhub account and a free "read,write,delete" authentication key.  
After that you just have to configure the secrets here for things to work
![image](https://user-images.githubusercontent.com/7483201/148650939-b38f73d0-2eb5-4fdd-bcfa-f061a2598517.png)   
  
I've only followed instructions and examples found here https://github.com/docker/build-push-action  
So, of course, there is room for improvement, with, for example a better tagging logic than just having a "latest" version.
  
Have a nice day 

PS: I would fancy having a working build process for armv7 for running on older Rapsberry Pi versions for example.  But i'm not planning to work it.
I've seen in the github actions logs when configuring for "linux/arm/v7" that the "cryptography" python library is causing an issue in the build process.
