### PR TITLE
Remove mock and nose development dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,8 +2,6 @@ coverage==4.5.1
 fakeredis==0.7.0
 flake8==3.5.0
 freezegun==0.3.15
-mock==2.0.0
-nose==1.3.7
 pytest-cov==2.5.1
 pytest==3.6.3
 tox==3.1.2

--- a/tests.py
+++ b/tests.py
@@ -1,10 +1,10 @@
-from mock import patch
 import re
 import time
 import unittest
 import uuid
 import json
 from unittest import TestCase
+from unittest import mock
 
 from cryptography.fernet import Fernet
 from freezegun import freeze_time
@@ -20,7 +20,7 @@ __author__ = 'davedash'
 
 class SnapPassTestCase(TestCase):
 
-    @patch('redis.client.StrictRedis', FakeStrictRedis)
+    @mock.patch('redis.client.StrictRedis', FakeStrictRedis)
     def test_get_password(self):
         password = "melatonin overdose 1337!$"
         key = snappass.set_password(password, 30)


### PR DESCRIPTION
We don't need 'mock' now that we require Python 3.x.

... and nose is no longer used since we switched to pytest as our test
runner a long time ago.