### PR TITLE
Remove dependency on six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ Jinja2==2.11.3
 MarkupSafe==1.1.1
 pycparser==2.20
 redis==2.10.6
-six==1.14.0
 Werkzeug==0.15.6

--- a/tests.py
+++ b/tests.py
@@ -5,12 +5,12 @@ import uuid
 import json
 from unittest import TestCase
 from unittest import mock
+from urllib.parse import unquote
 
 from cryptography.fernet import Fernet
 from freezegun import freeze_time
 from werkzeug.exceptions import BadRequest
 from fakeredis import FakeStrictRedis
-from six.moves.urllib.parse import unquote
 
 # noinspection PyPep8Naming
 import snappass.main as snappass


### PR DESCRIPTION
We no longer need six now that we require Python 3.x.