### PR TITLE
Support for werkzeuge 3.0.0

### DIFF
--- a/snappass/main.py
+++ b/snappass/main.py
@@ -7,8 +7,8 @@ import redis
 from cryptography.fernet import Fernet
 from flask import abort, Flask, render_template, request, jsonify
 from redis.exceptions import ConnectionError
-from werkzeug.urls import url_quote_plus
-from werkzeug.urls import url_unquote_plus
+from urllib.parse import quote_plus
+from urllib.parse import unquote_plus
 from distutils.util import strtobool
 
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
@@ -176,7 +176,7 @@ def handle_password():
             base_url = request.url_root.replace("http://", "https://")
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
-    link = base_url + url_quote_plus(token)
+    link = base_url + quote_plus(token)
     if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
         return jsonify(link=link, ttl=ttl)
     else:
@@ -185,7 +185,7 @@ def handle_password():
 
 @app.route('/<password_key>', methods=['GET'])
 def preview_password(password_key):
-    password_key = url_unquote_plus(password_key)
+    password_key = unquote_plus(password_key)
     if not password_exists(password_key):
         return render_template('expired.html'), 404
 
@@ -194,7 +194,7 @@ def preview_password(password_key):
 
 @app.route('/<password_key>', methods=['POST'])
 def show_password(password_key):
-    password_key = url_unquote_plus(password_key)
+    password_key = unquote_plus(password_key)
     password = get_password(password_key)
     if not password:
         return render_template('expired.html'), 404
@@ -209,3 +209,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
With the latest release of werkzeuge 3.0.0 snappass doesn't work anymore.

```
Traceback (most recent call last):
  File "/usr/local/bin/snappass", line 33, in <module>
    sys.exit(load_entry_point('snappass==1.6.0', 'console_scripts', 'snappass')())
  File "/usr/local/bin/snappass", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/local/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.8/site-packages/snappass-1.6.0-py3.8.egg/snappass/main.py", line 10, in <module>
    from werkzeug.urls import url_quote_plus
ImportError: cannot import name 'url_quote_plus' from 'werkzeug.urls' (/usr/local/lib/python3.8/site-packages/werkzeug-3.0.0-py3.8.egg/werkzeug/urls.py)
```

This fixes the usage of the removed functions as recommeded from the deprecation message - https://github.com/pallets/werkzeug/blob/2.3.x/src/werkzeug/urls.py#L643