### PR TITLE
Support Debian Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 redis==5.0.1
-Werkzeug==2.3.3

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -7,8 +7,8 @@ import redis
 from cryptography.fernet import Fernet
 from flask import abort, Flask, render_template, request, jsonify
 from redis.exceptions import ConnectionError
-from werkzeug.urls import url_quote_plus
-from werkzeug.urls import url_unquote_plus
+from urllib.parse import quote_plus
+from urllib.parse import unquote_plus
 from distutils.util import strtobool
 
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
@@ -176,7 +176,7 @@ def handle_password():
             base_url = request.url_root.replace("http://", "https://")
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
-    link = base_url + url_quote_plus(token)
+    link = base_url + quote_plus(token)
     if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
         return jsonify(link=link, ttl=ttl)
     else:
@@ -185,7 +185,7 @@ def handle_password():
 
 @app.route('/<password_key>', methods=['GET'])
 def preview_password(password_key):
-    password_key = url_unquote_plus(password_key)
+    password_key = unquote_plus(password_key)
     if not password_exists(password_key):
         return render_template('expired.html'), 404
 
@@ -194,7 +194,7 @@ def preview_password(password_key):
 
 @app.route('/<password_key>', methods=['POST'])
 def show_password(password_key):
-    password_key = url_unquote_plus(password_key)
+    password_key = unquote_plus(password_key)
     password = get_password(password_key)
     if not password:
         return render_template('expired.html'), 404


### PR DESCRIPTION
Replace werkzeug.urls with urllib.parse because werkzeug.urls.url_unquote and werkzeug.urls.url_quote are removed in Werkzeug 3.0. 

see https://werkzeug.palletsprojects.com/en/2.3.x/urls/#werkzeug.urls.url_unquote_plus