### PR TITLE
Use urllib.parse for quoting/unquoting plus instead of deprecated werkzeug.urls

### DIFF
--- a/snappass/main.py
+++ b/snappass/main.py
@@ -7,8 +7,8 @@ import redis
 from cryptography.fernet import Fernet
 from flask import abort, Flask, render_template, request, jsonify
 from redis.exceptions import ConnectionError
-from werkzeug.urls import url_quote_plus
-from werkzeug.urls import url_unquote_plus
+from urllib.parse import quote_plus
+from urllib.parse import unquote_plus
 from distutils.util import strtobool
 
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
@@ -176,7 +176,7 @@ def handle_password():
             base_url = request.url_root.replace("http://", "https://")
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
-    link = base_url + url_quote_plus(token)
+    link = base_url + quote_plus(token)
     if request.accept_mimetypes.accept_json and not request.accept_mimetypes.accept_html:
         return jsonify(link=link, ttl=ttl)
     else:
@@ -185,7 +185,7 @@ def handle_password():
 
 @app.route('/<password_key>', methods=['GET'])
 def preview_password(password_key):
-    password_key = url_unquote_plus(password_key)
+    password_key = unquote_plus(password_key)
     if not password_exists(password_key):
         return render_template('expired.html'), 404
 
@@ -194,7 +194,7 @@ def preview_password(password_key):
 
 @app.route('/<password_key>', methods=['POST'])
 def show_password(password_key):
-    password_key = url_unquote_plus(password_key)
+    password_key = unquote_plus(password_key)
     password = get_password(password_key)
     if not password:
         return render_template('expired.html'), 404


### PR DESCRIPTION
werkzeug.urls.url_quote_plus and werkzeug.urls.url_unquote_plus were [deprecated](https://github.com/pallets/werkzeug/blob/2.3.x/src/werkzeug/urls.py#L645) and are removed in 3.0.0 and newer versions.

might address https://github.com/pinterest/snappass/issues/299 where recent Werkzeug version is needed for Flask (https://github.com/pallets/flask/commit/3252f2bc546759a94f7a4c4938ef561d7bb6a6ec)