### PR TITLE
add /api endpoint for automated flows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ To create a password, send a POST request to ``/api/set_password`` like so:
 
 ::
 
-    $ curl -X POST -H "Content-Type: application/json"  http://localhost:5000/api/set_password/my_password
+    $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar"}' http://localhost:5000/api/set_password/
 
 This will return a JSON response with the password link:
 
@@ -122,9 +122,13 @@ the default TTL is 2 weeks (1209600 seconds), but you can override it by adding 
 
 ::
 
-    $ curl -X POST -H "Content-Type: application/json"  http://localhost:5000/api/set_password/my_password/week
+    $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar", "ttl": 3600 }' http://localhost:5000/api/set_password/
 
-Depending on the environment you are running it, you might want to expose the ``/api`` endpoint to your internal network only, and put the web interface behind authentication.
+Notes:
+
+- When using the API, you can specify any ttl, as long as it is lower than the default.
+- The password is passed in the body of the request rather than in the URL. This is to prevent the password from being logged in the server logs.
+- Depending on the environment you are running it, you might want to expose the ``/api`` endpoint to your internal network only, and put the web interface behind authentication.
 
 Docker
 ------

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,36 @@ need to change this.
 
 ``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
+API
+---
+
+SnapPass also has a simple API that can be used to create passwords links. The advantage of using the API is that
+you can create a password and retrieve the link without having to open the web interface. This is useful if you want to
+embed it in a script or use it in a CI/CD pipeline.
+
+To create a password, send a POST request to ``/api/set_password`` like so:
+
+::
+
+    $ curl -X POST -H "Content-Type: application/json"  http://localhost:5000/api/set_password/my_password
+
+This will return a JSON response with the password link:
+
+::
+
+    {
+        "link": "http://127.0.0.1:5000/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
+        "ttl":1209600
+    }
+
+the default TTL is 2 weeks (1209600 seconds), but you can override it by adding a expiration parameter:
+
+::
+
+    $ curl -X POST -H "Content-Type: application/json"  http://localhost:5000/api/set_password/my_password/week
+
+Depending on the environment you are running it, you might want to expose the ``/api`` endpoint to your internal network only, and put the web interface behind authentication.
+
 Docker
 ------
 

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import json
 import re
 import time
 import unittest
@@ -144,6 +145,7 @@ class SnapPassRoutesTestCase(TestCase):
             frozen_time.move_to("2020-05-22 12:00:00")
             self.assertIsNone(snappass.get_password(key))
 
+
     def test_set_password_json(self):
         with freeze_time("2020-05-08 12:00:00") as frozen_time:
             password = 'my name is my passport. verify me.'
@@ -163,6 +165,43 @@ class SnapPassRoutesTestCase(TestCase):
             frozen_time.move_to("2020-05-22 12:00:00")
             self.assertIsNone(snappass.get_password(key))
 
+    def test_set_password_api(self):
+        with freeze_time("2020-05-08 12:00:00") as frozen_time:
+            password = 'my name is my passport. verify me.'
+            rv = self.app.post(
+                '/api/set_password/',
+                headers={'Accept': 'application/json'},
+                json={'password': password, 'ttl': '1209600'},
+            )
+
+            json_content = rv.get_json()
+            key = re.search(r'https://localhost/([^"]+)', json_content['link']).group(1)
+            key = unquote(key)
+
+            frozen_time.move_to("2020-05-22 11:59:59")
+            self.assertEqual(snappass.get_password(key), password)
+
+            frozen_time.move_to("2020-05-22 12:00:00")
+            self.assertIsNone(snappass.get_password(key))
+
+    def test_set_password_api_default_ttl(self):
+        with freeze_time("2020-05-08 12:00:00") as frozen_time:
+            password = 'my name is my passport. verify me.'
+            rv = self.app.post(
+                '/api/set_password/',
+                headers={'Accept': 'application/json'},
+                json={'password': password},
+            )
+
+            json_content = rv.get_json()
+            key = re.search(r'https://localhost/([^"]+)', json_content['link']).group(1)
+            key = unquote(key)
+
+            frozen_time.move_to("2020-05-22 11:59:59")
+            self.assertEqual(snappass.get_password(key), password)
+
+            frozen_time.move_to("2020-05-22 12:00:00")
+            self.assertIsNone(snappass.get_password(key))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,3 @@
-import json
 import re
 import time
 import unittest
@@ -145,7 +144,6 @@ class SnapPassRoutesTestCase(TestCase):
             frozen_time.move_to("2020-05-22 12:00:00")
             self.assertIsNone(snappass.get_password(key))
 
-
     def test_set_password_json(self):
         with freeze_time("2020-05-08 12:00:00") as frozen_time:
             password = 'my name is my passport. verify me.'
@@ -202,6 +200,7 @@ class SnapPassRoutesTestCase(TestCase):
 
             frozen_time.move_to("2020-05-22 12:00:00")
             self.assertIsNone(snappass.get_password(key))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
To enable automation of sending passwords securely to human users, this MR adds and /api endpoint to set a password. 

since this endpoint uses a different root path, the upstream proxy can whitelist it for the internal network, while the normal / path can be configured to need authentication