### PR TITLE
Environment variables for default port and bind address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,10 @@ need to change this.
 
 ``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
+``BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
+
+``PORT``: (optional) Used to override the default port of 5000 Example: ``6000``
+
 API
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -96,9 +96,9 @@ need to change this.
 
 ``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
-``BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
+``SNAPPASS_BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
 
-``PORT``: (optional) Used to override the default port of 5000 Example: ``6000``
+``SNAPPASS_PORT``: (optional) Used to override the default port of 5000 Example: ``6000``
 
 APIs
 ----

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -246,7 +246,8 @@ def health_check():
 
 @check_redis_alive
 def main():
-    app.run(host='0.0.0.0')
+    app.run(host=os.environ.get('BIND_ADDRESS', '0.0.0.0'),
+            port=os.environ.get('PORT', 5000))
 
 
 if __name__ == '__main__':

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -353,8 +353,8 @@ def health_check():
 
 @check_redis_alive
 def main():
-    app.run(host=os.environ.get('BIND_ADDRESS', '0.0.0.0'),
-            port=os.environ.get('PORT', 5000))
+    app.run(host=os.environ.get('SNAPPASS_BIND_ADDRESS', '0.0.0.0'),
+            port=os.environ.get('SNAPPASS_PORT', 5000))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

There is not an open issue for this but I ran into an issue where I could not change the default port or bind address for snappass. In my case I installed via pip and wanted to bind snappass to 127.0.0.1 as I am planning to use a reverse proxy to reach the app. Is it possible to add the following two environment variables?

BIND_ADDRESS = 127.0.0.1
PORT = 6000

I tested that with no environment variables set, the defaults of 0.0.0.0:5000 are set and working. Given the following variables
```bash
BIND_ADDRESS = 127.0.0.1
PORT = 6000
HOST_OVERIDE = example.com
```
I can reach the app and links are generated with the appropriate URL.

ps. This is my first time submitting a PR, I apologize if I am missing anything.

Thanks all!
