### PR TITLE
Adding APIs to manage password lifecycle

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,7 @@ This will return a JSON response with a token and the password link:
 
     {
         "token": "snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
+        "token": "snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY=",
         "links": [{
             "rel": "self",
             "href": "http://127.0.0.1:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
@@ -187,7 +188,7 @@ Otherwise, the API will return a 404 (Not Found) response like so:
 Check if a password exists
 """"""""""""""""""""""""""
 
-To check if a password exists, send a HEAD request to ``/api/v2/passwords/<password_key>``, where ``<password_key>`` is the token of the API response when a password is created, or simply use the `self` link:
+To check if a password exists, send a HEAD request to ``/api/v2/passwords/<token>``, where ``<token>`` is the token of the API response when a password is created (url encoded), or simply use the `self` link:
 
 ::
 
@@ -233,9 +234,9 @@ To read a password, send a GET request to ``/api/v2/passwords/<password_key>``, 
     $ curl -X GET http://localhost:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D
 
 If :
-- the passwork_key is valid 
+- the token is valid 
 - the password :
-  - exists,
+  - exists
   - has not been read 
   - is not expired
 

--- a/README.rst
+++ b/README.rst
@@ -151,11 +151,13 @@ This will return a JSON response with a token and the password link:
 ::
 
     {
-        "token": "snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
         "token": "snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY=",
         "links": [{
             "rel": "self",
             "href": "http://127.0.0.1:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
+        },{
+            "rel": "web-view",
+            "href": "http://127.0.0.1:5000/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
         }],
         "ttl":1209600
     }

--- a/README.rst
+++ b/README.rst
@@ -96,12 +96,17 @@ need to change this.
 
 ``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
-API
----
+APIs
+----
 
-SnapPass also has a simple API that can be used to create passwords links. The advantage of using the API is that
-you can create a password and retrieve the link without having to open the web interface. This is useful if you want to
-embed it in a script or use it in a CI/CD pipeline.
+SnapPass has 2 APIs :
+1. A simple API : That can be used to create passwords links, and then share them with users
+2. A more REST-y API : Which facilitate programmatic interactions with SnapPass, without having to parse HTML content when retrieving the password
+
+Simple API
+^^^^^^^^^^
+
+The advantage of using the simple API is that you can create a password and retrieve the link without having to open the web interface. This is useful if you want to embed it in a script or use it in a CI/CD pipeline.
 
 To create a password, send a POST request to ``/api/set_password`` like so:
 
@@ -124,11 +129,145 @@ the default TTL is 2 weeks (1209600 seconds), but you can override it by adding 
 
     $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar", "ttl": 3600 }' http://localhost:5000/api/set_password/
 
+
+REST API
+^^^^^^^^
+
+The advantage of using the REST API is that you can fully manage the lifecycle of the password stored in SnapPass without having to interact with any web user interface.
+
+This is useful if you want to embed it in a script,  use it in a CI/CD pipeline or share it between multiple client applications.
+
+Create a password
+"""""""""""""""""
+
+To create a password, send a POST request to ``/api/v2/passwords`` like so:
+
+::
+
+    $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar"}' http://localhost:5000/api/v2/passwords
+
+This will return a JSON response with a token and the password link:
+
+::
+
+    {
+        "token": "snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
+        "links": [{
+            "rel": "self",
+            "href": "http://127.0.0.1:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D",
+        }],
+        "ttl":1209600
+    }
+
+The default TTL is 2 weeks (1209600 seconds), but you can override it by adding a expiration parameter:
+
+::
+
+    $ curl -X POST -H "Content-Type: application/json"  -d '{"password": "foobar", "ttl": 3600 }' http://localhost:5000/api/v2/passwords
+
+If the password is null or empty, and the TTL is larger than the max TTL of the application, the API will return an error like this:
+
+
+Otherwise, the API will return a 404 (Not Found) response like so:
+
+::
+
+    {
+        "invalid-params": [{
+            "name": "password",
+            "reason": "The password is required and should not be null or empty."
+        }, {
+            "name": "ttl",
+            "reason": "The specified TTL is longer than the maximum supported."
+        }],
+        "title": "The password and/or the TTL are invalid.",
+        "type": "https://127.0.0.1:5000/set-password-validation-error"
+    }
+
+Check if a password exists
+""""""""""""""""""""""""""
+
+To check if a password exists, send a HEAD request to ``/api/v2/passwords/<password_key>``, where ``<password_key>`` is the token of the API response when a password is created, or simply use the `self` link:
+
+::
+
+    $ curl --head http://localhost:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D
+
+If :
+- the passwork_key is valid 
+- the password :
+  - exists,
+  - has not been read 
+  - is not expired
+
+Then the API will return a 200 (OK) response like so:
+
+::
+
+    HTTP/1.1 200 OK
+    Server: Werkzeug/3.0.1 Python/3.12.2
+    Date: Fri, 29 Mar 2024 22:15:54 GMT
+    Content-Type: text/html; charset=utf-8
+    Content-Length: 0
+    Connection: close
+
+Otherwise, the API will return a 404 (Not Found) response like so:
+
+::
+
+    HTTP/1.1 404 NOT FOUND
+    Server: Werkzeug/3.0.1 Python/3.12.2
+    Date: Fri, 29 Mar 2024 22:19:29 GMT
+    Content-Type: text/html; charset=utf-8
+    Content-Length: 0
+    Connection: close
+    
+
+Read a password
+"""""""""""""""
+
+To read a password, send a GET request to ``/api/v2/passwords/<password_key>``, where ``<password_key>`` is the token of the API response when a password is created, or simply use the `self` link:
+
+::
+
+    $ curl -X GET http://localhost:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D
+
+If :
+- the passwork_key is valid 
+- the password :
+  - exists,
+  - has not been read 
+  - is not expired
+
+Then the API will return a 200 (OK) with a JSON response containing the password :
+
+::
+
+    {
+        "password": "foobar"
+    }
+
+Otherwise, the API will return a 404 (Not Found) response like so:
+
+::
+
+    {
+        "invalid-params": [{
+            "name": "token"
+        }],
+        "title": "The password doesn't exist.",
+        "type": "https://127.0.0.1:5000/get-password-error"
+    }
+
+Notes on APIs
+^^^^^^^^^^^^^
+
 Notes:
 
-- When using the API, you can specify any ttl, as long as it is lower than the default.
+- When using the APIs, you can specify any ttl, as long as it is lower than the default.
 - The password is passed in the body of the request rather than in the URL. This is to prevent the password from being logged in the server logs.
 - Depending on the environment you are running it, you might want to expose the ``/api`` endpoint to your internal network only, and put the web interface behind authentication.
+
 
 Docker
 ------

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -248,7 +248,7 @@ def api_handle_password():
     else:
         abort(500)
 
-@app.route('/api/v2/passwords/', methods=['POST'])
+@app.route('/api/v2/passwords', methods=['POST'])
 def api_v2_set_password():
     password = request.json.get('password')
     ttl = int(request.json.get('ttl', DEFAULT_API_TTL))
@@ -272,9 +272,18 @@ def api_v2_set_password():
         return as_validation_problem(request, "set-password-validation-error", "The password and/or the TTL are invalid.", invalid_params)
 
     token = set_password(password, ttl)
+    url_token= quote_plus(token)
     base_url = set_base_url(request)
-    link = urljoin(base_url, request.path + quote_plus(token))
-    return jsonify(link=link, ttl=ttl)
+    link = urljoin(base_url, request.path + "/" + url_token)
+    response_content = {
+        "token": url_token,
+        "links": [{
+            "rel": "self",
+            "href": link
+        }],
+        "ttl": ttl
+    }
+    return jsonify(response_content)
 
 @app.route('/api/v2/passwords/<token>', methods=['HEAD'])
 def api_v2_check_password(token):

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -217,6 +217,47 @@ def api_handle_password():
         return jsonify(link=link, ttl=ttl)
     else:
         abort(500)
+        
+@app.route('/api/v2/passwords/', methods=['POST'])
+def api_v2_set_password():
+    password = request.json.get('password')
+    ttl = int(request.json.get('ttl', DEFAULT_API_TTL))
+    if not password:
+        # Add ProblemDetails expliciting issue with Password and/or TTL
+        abort(400)
+        
+    if not isinstance(ttl, int) or ttl > MAX_TTL:
+    else:
+        # Return ProblemDetails expliciting issue
+        abort(400)
+        
+    token = set_password(password, ttl)
+    base_url = set_base_url(request)
+    link = base_url + quote_plus(token)
+    return jsonify(link=link, ttl=ttl)
+
+@app.route('/api/v2/passwords/<password_key>', methods=['HEAD'])
+def api_v2_check_password():
+    password_key = unquote_plus(password_key)
+    if not password_exists(password_key):
+        # Return NotFound, to indicate that password does not exists (anymore or at all)
+        # With ProblemDetails expliciting issue (just password not found)
+        abort(404)
+    else:
+        # Return OK, to indicate that password still exists
+        abort(200)
+
+@app.route('/api/v2/passwords/<password_key>', methods=['GET'])
+def api_v2_retrieve_password():
+    password_key = unquote_plus(password_key)
+    password = get_password(password_key)
+    if not password:
+        # Return NotFound, to indicate that password does not exists (anymore or at all)
+        # With ProblemDetails expliciting issue (just password not found)
+        abort(404)
+    else:
+        # Return OK and the password in JSON message
+        return jsonify(passwork=passwork)
 
 
 @app.route('/<password_key>', methods=['GET'])

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -285,6 +285,7 @@ def api_v2_set_password():
     link = urljoin(base_url, request.path + "/" + url_token)
     response_content = {
         "token": url_token,
+        "token": token,
         "links": [{
             "rel": "self",
             "href": link

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -101,7 +101,7 @@ def parse_token(token):
         decryption_key = None
 
     return storage_key, decryption_key
-    
+
 def as_validation_problem(request, problem_type, problem_title, invalid_params):
     base_url = set_base_url(request)
 
@@ -247,12 +247,12 @@ def api_handle_password():
         return jsonify(link=link, ttl=ttl)
     else:
         abort(500)
-        
+
 @app.route('/api/v2/passwords/', methods=['POST'])
 def api_v2_set_password():
     password = request.json.get('password')
     ttl = int(request.json.get('ttl', DEFAULT_API_TTL))
-    
+
     invalid_params = []
 
     if not password:

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -276,23 +276,23 @@ def api_v2_set_password():
     link = urljoin(base_url, request.path + quote_plus(token))
     return jsonify(link=link, ttl=ttl)
 
-@app.route('/api/v2/passwords/<password_key>', methods=['HEAD'])
-def api_v2_check_password(password_key):
-    password_key = unquote_plus(password_key)
-    if not password_exists(password_key):
+@app.route('/api/v2/passwords/<token>', methods=['HEAD'])
+def api_v2_check_password(token):
+    token = unquote_plus(token)
+    if not password_exists(token):
         # Return NotFound, to indicate that password does not exists (anymore or at all)
         return ('', 404)
     else:
         # Return OK, to indicate that password still exists
         return ('', 200)
 
-@app.route('/api/v2/passwords/<password_key>', methods=['GET'])
-def api_v2_retrieve_password(password_key):
-    password_key = unquote_plus(password_key)
-    password = get_password(password_key)
+@app.route('/api/v2/passwords/<token>', methods=['GET'])
+def api_v2_retrieve_password(token):
+    token = unquote_plus(token)
+    password = get_password(token)
     if not password:
         # Return NotFound, to indicate that password does not exists (anymore or at all)
-        return as_not_found_problem(request, "get-password-error", "The password doesn't exist.", [{ "name": "password_key"}])
+        return as_not_found_problem(request, "get-password-error", "The password doesn't exist.", [{ "name": "token"}])
     else:
         # Return OK and the password in JSON message
         return jsonify(password=password)

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -102,6 +102,7 @@ def parse_token(token):
 
     return storage_key, decryption_key
 
+
 def as_validation_problem(request, problem_type, problem_title, invalid_params):
     base_url = set_base_url(request)
 
@@ -111,6 +112,7 @@ def as_validation_problem(request, problem_type, problem_title, invalid_params):
         "invalid-params": invalid_params
     }
     return as_problem_response(problem)
+
 
 def as_not_found_problem(request, problem_type, problem_title, invalid_params):
     base_url = set_base_url(request)
@@ -248,6 +250,7 @@ def api_handle_password():
     else:
         abort(500)
 
+
 @app.route('/api/v2/passwords', methods=['POST'])
 def api_v2_set_password():
     password = request.json.get('password')
@@ -269,10 +272,15 @@ def api_v2_set_password():
 
     if len(invalid_params) > 0:
         # Return a ProblemDetails expliciting issue with Password and/or TTL
-        return as_validation_problem(request, "set-password-validation-error", "The password and/or the TTL are invalid.", invalid_params)
+        return as_validation_problem(
+            request,
+            "set-password-validation-error",
+            "The password and/or the TTL are invalid.",
+            invalid_params
+        )
 
     token = set_password(password, ttl)
-    url_token= quote_plus(token)
+    url_token = quote_plus(token)
     base_url = set_base_url(request)
     link = urljoin(base_url, request.path + "/" + url_token)
     response_content = {
@@ -285,6 +293,7 @@ def api_v2_set_password():
     }
     return jsonify(response_content)
 
+
 @app.route('/api/v2/passwords/<token>', methods=['HEAD'])
 def api_v2_check_password(token):
     token = unquote_plus(token)
@@ -295,13 +304,19 @@ def api_v2_check_password(token):
         # Return OK, to indicate that password still exists
         return ('', 200)
 
+
 @app.route('/api/v2/passwords/<token>', methods=['GET'])
 def api_v2_retrieve_password(token):
     token = unquote_plus(token)
     password = get_password(token)
     if not password:
         # Return NotFound, to indicate that password does not exists (anymore or at all)
-        return as_not_found_problem(request, "get-password-error", "The password doesn't exist.", [{ "name": "token"}])
+        return as_not_found_problem(
+            request,
+            "get-password-error",
+            "The password doesn't exist.",
+            [{"name": "token"}]
+        )
     else:
         # Return OK and the password in JSON message
         return jsonify(password=password)

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -282,13 +282,16 @@ def api_v2_set_password():
     token = set_password(password, ttl)
     url_token = quote_plus(token)
     base_url = set_base_url(request)
-    link = urljoin(base_url, request.path + "/" + url_token)
+    api_link = urljoin(base_url, request.path + "/" + url_token)
+    web_link = urljoin(base_url, url_token)
     response_content = {
-        "token": url_token,
         "token": token,
         "links": [{
             "rel": "self",
-            "href": link
+            "href": api_link
+        }, {
+            "rel": "web-view",
+            "href": web_link
         }],
         "ttl": ttl
     }

--- a/tests.py
+++ b/tests.py
@@ -239,126 +239,118 @@ class SnapPassRoutesTestCase(TestCase):
             self.assertIsNone(snappass.get_password(key))
 
     def test_set_password_api_v2_no_password(self):
-        with freeze_time("2020-05-08 12:00:00") as frozen_time:
-            rv = self.app.post(
-                '/api/v2/passwords',
-                headers={'Accept': 'application/json'},
-                json={'password': ''},
-            )
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': ''},
+        )
 
-            self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 400)
 
-            json_content = rv.get_json()
-            invalid_params = json_content['invalid-params']
-            self.assertEqual(len(invalid_params), 1)
-            bad_password = invalid_params[0]
-            self.assertEqual(bad_password['name'], 'password')
-            
+        json_content = rv.get_json()
+        invalid_params = json_content['invalid-params']
+        self.assertEqual(len(invalid_params), 1)
+        bad_password = invalid_params[0]
+        self.assertEqual(bad_password['name'], 'password')
+
     def test_set_password_api_v2_too_big_ttl(self):
-        with freeze_time("2020-05-08 12:00:00") as frozen_time:
-            password = 'my name is my passport. verify me.'
-            rv = self.app.post(
-                '/api/v2/passwords',
-                headers={'Accept': 'application/json'},
-                json={'password': password, 'ttl': '1209600000'},
-            )
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password, 'ttl': '1209600000'},
+        )
 
-            self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 400)
 
-            json_content = rv.get_json()
-            invalid_params = json_content['invalid-params']
-            self.assertEqual(len(invalid_params), 1)
-            bad_ttl = invalid_params[0]
-            self.assertEqual(bad_ttl['name'], 'ttl')
-            
+        json_content = rv.get_json()
+        invalid_params = json_content['invalid-params']
+        self.assertEqual(len(invalid_params), 1)
+        bad_ttl = invalid_params[0]
+        self.assertEqual(bad_ttl['name'], 'ttl')
+
     def test_set_password_api_v2_no_password_and_too_big_ttl(self):
-        with freeze_time("2020-05-08 12:00:00") as frozen_time:
-            password = 'my name is my passport. verify me.'
-            rv = self.app.post(
-                '/api/v2/passwords',
-                headers={'Accept': 'application/json'},
-                json={'password': '', 'ttl': '1209600000'},
-            )
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': '', 'ttl': '1209600000'},
+        )
 
-            self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 400)
 
-            json_content = rv.get_json()
-            invalid_params = json_content['invalid-params']
-            self.assertEqual(len(invalid_params), 2)
-            bad_password = invalid_params[0]
-            self.assertEqual(bad_password['name'], 'password')
-            bad_ttl = invalid_params[1]
-            self.assertEqual(bad_ttl['name'], 'ttl')
+        json_content = rv.get_json()
+        invalid_params = json_content['invalid-params']
+        self.assertEqual(len(invalid_params), 2)
+        bad_password = invalid_params[0]
+        self.assertEqual(bad_password['name'], 'password')
+        bad_ttl = invalid_params[1]
+        self.assertEqual(bad_ttl['name'], 'ttl')
 
     def test_check_password_api_v2(self):
-        with freeze_time("2020-05-08 12:00:00") as frozen_time:
-            password = 'my name is my passport. verify me.'
-            rv = self.app.post(
-                '/api/v2/passwords',
-                headers={'Accept': 'application/json'},
-                json={'password': password},
-            )
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password},
+        )
 
-            json_content = rv.get_json()
-            key = unquote(json_content['token'])
-            
-            rvc = self.app.head('/api/v2/passwords/' + quote(key))
-            self.assertEqual(rv.status_code, 200)
+        json_content = rv.get_json()
+        key = unquote(json_content['token'])
+
+        rvc = self.app.head('/api/v2/passwords/' + quote(key))
+        self.assertEqual(rvc.status_code, 200)
 
     def test_check_password_api_v2_bad_keys(self):
-        with freeze_time("2020-05-08 12:00:00") as frozen_time:
-            password = 'my name is my passport. verify me.'
-            rv = self.app.post(
-                '/api/v2/passwords',
-                headers={'Accept': 'application/json'},
-                json={'password': password},
-            )
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password},
+        )
 
-            json_content = rv.get_json()
-            key = unquote(json_content['token'])
-            
-            rvc = self.app.head('/api/v2/passwords/' + quote(key[::-1]))
-            self.assertEqual(rvc.status_code, 404)
+        json_content = rv.get_json()
+        key = unquote(json_content['token'])
+
+        rvc = self.app.head('/api/v2/passwords/' + quote(key[::-1]))
+        self.assertEqual(rvc.status_code, 404)
 
     def test_retrieve_password_api_v2(self):
-        with freeze_time("2020-05-08 12:00:00") as frozen_time:
-            password = 'my name is my passport. verify me.'
-            rv = self.app.post(
-                '/api/v2/passwords',
-                headers={'Accept': 'application/json'},
-                json={'password': password},
-            )
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password},
+        )
 
-            json_content = rv.get_json()
-            key = unquote(json_content['token'])
-            
-            rvc = self.app.get('/api/v2/passwords/' + quote(key))
-            self.assertEqual(rv.status_code, 200)
+        json_content = rv.get_json()
+        key = unquote(json_content['token'])
 
-            json_content_retrieved = rvc.get_json()
-            retrieved_password = json_content_retrieved['password']
-            self.assertEqual(retrieved_password, password)
+        rvc = self.app.get('/api/v2/passwords/' + quote(key))
+        self.assertEqual(rv.status_code, 200)
+
+        json_content_retrieved = rvc.get_json()
+        retrieved_password = json_content_retrieved['password']
+        self.assertEqual(retrieved_password, password)
 
     def test_retrieve_password_api_v2_bad_keys(self):
-        with freeze_time("2020-05-08 12:00:00") as frozen_time:
-            password = 'my name is my passport. verify me.'
-            rv = self.app.post(
-                '/api/v2/passwords',
-                headers={'Accept': 'application/json'},
-                json={'password': password},
-            )
+        password = 'my name is my passport. verify me.'
+        rv = self.app.post(
+            '/api/v2/passwords',
+            headers={'Accept': 'application/json'},
+            json={'password': password},
+        )
 
-            json_content = rv.get_json()
-            key = unquote(json_content['token'])
-            
-            rvc = self.app.get('/api/v2/passwords/' + quote(key[::-1]))
-            self.assertEqual(rvc.status_code, 404)
-            
-            json_content_retrieved = rvc.get_json()
-            invalid_params = json_content_retrieved['invalid-params']
-            self.assertEqual(len(invalid_params), 1)
-            bad_token = invalid_params[0]
-            self.assertEqual(bad_token['name'], 'token')
+        json_content = rv.get_json()
+        key = unquote(json_content['token'])
+
+        rvc = self.app.get('/api/v2/passwords/' + quote(key[::-1]))
+        self.assertEqual(rvc.status_code, 404)
+
+        json_content_retrieved = rvc.get_json()
+        invalid_params = json_content_retrieved['invalid-params']
+        self.assertEqual(len(invalid_params), 1)
+        bad_token = invalid_params[0]
+        self.assertEqual(bad_token['name'], 'token')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

I've added 3 new API endpoints to the server, alongside the current one implemented :
1. POST `/api/v2/passwords` : Allow to create a new password
1. HEAD `/api/v2/passwords/<token>` : Check if a password exsists/has been read
1. POST `/api/v2/passwords/<token>` : Get a password

The goal of these APIs is to facilitate programmatic interactions with SnapPass.

I've added test to ensure that the APIs work correctly and filled documentation with them.