### PR TITLE
Add environment variable REDIS_PASSWORD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,8 @@ need to change this.
 
 ``REDIS_PORT``: is the port redis is serving on, defaults to 6379
 
+``REDIS_PASSWORD``: in certain environments authtentication may be a requirement. Defaults to ``"None"``
+
 ``SNAPPASS_REDIS_DB``: is the database that you want to use on this redis server. Defaults to db 0
 
 ``REDIS_URL``: (optional) will be used instead of ``REDIS_HOST``, ``REDIS_PORT``, and ``SNAPPASS_REDIS_DB`` to configure the Redis client object. For example: redis://username:password@localhost:6379/0
@@ -197,10 +199,10 @@ To check if a password exists, send a HEAD request to ``/api/v2/passwords/<token
     $ curl --head http://localhost:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D
 
 If :
-- the passwork_key is valid 
+- the passwork_key is valid
 - the password :
   - exists,
-  - has not been read 
+  - has not been read
   - is not expired
 
 Then the API will return a 200 (OK) response like so:
@@ -224,7 +226,7 @@ Otherwise, the API will return a 404 (Not Found) response like so:
     Content-Type: text/html; charset=utf-8
     Content-Length: 0
     Connection: close
-    
+
 
 Read a password
 """""""""""""""
@@ -236,10 +238,10 @@ To read a password, send a GET request to ``/api/v2/passwords/<password_key>``, 
     $ curl -X GET http://localhost:5000/api/v2/passwords/snappassbedf19b161794fd288faec3eba15fa41~hHnILpQ50ZfJc3nurDfHCb_22rBr5gGEya68e_cZOrY%3D
 
 If :
-- the token is valid 
+- the token is valid
 - the password :
   - exists
-  - has not been read 
+  - has not been read
   - is not expired
 
 Then the API will return a 200 (OK) with a JSON response containing the password :

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -44,9 +44,10 @@ elif os.environ.get('REDIS_URL'):
 else:
     redis_host = os.environ.get('REDIS_HOST', 'localhost')
     redis_port = os.environ.get('REDIS_PORT', 6379)
+    redis_password = os.environ.get('REDIS_PASSWORD', 'None')
     redis_db = os.environ.get('SNAPPASS_REDIS_DB', 0)
     redis_client = redis.StrictRedis(
-        host=redis_host, port=redis_port, db=redis_db)
+        host=redis_host, port=redis_port, db=redis_db, password=redis_password)
 REDIS_PREFIX = os.environ.get('REDIS_PREFIX', 'snappass')
 
 TIME_CONVERSION = {'two weeks': 1209600, 'week': 604800, 'day': 86400,


### PR DESCRIPTION
This change allows to set a Redis password without the need to build up a whole REDIS_URL environment variable. The change is backward compatible as the default is set to "None", which is the default for redis.StrictRedis() according to the [documentation](https://redis-py2.readthedocs.io/en/latest/).

With this change, deployment in a container app on Azure using a add-on Redis is then super simple as the env vars REDIS_HOST, REDIS_PORT and REDIS_PASSWORD are injected automatically by the platform.

Fixes #369
