### PR TITLE
[Documentation] Visualization of the python logic in snappass

### DIFF
--- a/.codeboarding/API_Endpoints.md
+++ b/.codeboarding/API_Endpoints.md
@@ -1,0 +1,155 @@
+```mermaid
+
+graph LR
+
+    Main_Application["Main Application"]
+
+    API_Endpoints["API Endpoints"]
+
+    Templates["Templates"]
+
+    Static_Assets["Static Assets"]
+
+    Internationalization_Translations["Internationalization/Translations"]
+
+    Main_Application -- "renders" --> Templates
+
+    Main_Application -- "serves" --> Static_Assets
+
+    Main_Application -- "uses" --> Internationalization_Translations
+
+    Main_Application -- "provides core logic to" --> API_Endpoints
+
+    Templates -- "linked to" --> Static_Assets
+
+    Templates -- "receives content from" --> Internationalization_Translations
+
+    click API_Endpoints href "https://github.com/pinterest/snappass/blob/master/.codeboarding//API_Endpoints.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Abstract Components Overview for snappass project
+
+
+
+### Main Application
+
+This is the central orchestrator of the `snappass` web application. It acts as the primary Flask application instance, handling URL routing, processing incoming HTTP requests, and coordinating interactions between other components. It encapsulates the core business logic for managing ephemeral passwords, including encryption, decryption, and interaction with the Redis storage. It also renders HTML templates and serves static assets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L355-L357" target="_blank" rel="noopener noreferrer">`snappass.main` (355:357)</a>
+
+
+
+
+
+### API Endpoints [[Expand]](./API_Endpoints.md)
+
+This component exposes RESTful API interfaces for programmatic interaction with the ephemeral password service. It handles JSON request parsing, input validation (e.g., password strength, TTL), and constructs structured JSON responses, including error details. It leverages the core logic within the "Main Application" component to perform password-related operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L242-L251" target="_blank" rel="noopener noreferrer">`snappass.main:api_handle_password` (242:251)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L255-L298" target="_blank" rel="noopener noreferrer">`snappass.main:api_v2_set_password` (255:298)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L302-L309" target="_blank" rel="noopener noreferrer">`snappass.main:api_v2_check_password` (302:309)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L313-L326" target="_blank" rel="noopener noreferrer">`snappass.main:api_v2_retrieve_password` (313:326)</a>
+
+
+
+
+
+### Templates
+
+This component comprises the Jinja2 HTML templates responsible for rendering the user interface. They represent the "View" in the Model-View-Template (MVT) pattern, dynamically displaying data provided by the "Main Application" component. These templates define the structure and presentation of the web pages.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `snappass.templates.base.html` (1:1)
+
+- `snappass.templates.confirm.html` (1:1)
+
+- `snappass.templates.password.html` (1:1)
+
+- `snappass.templates.preview.html` (1:1)
+
+- `snappass.templates.set_password.html` (1:1)
+
+- `snappass.templates.expired.html` (1:1)
+
+
+
+
+
+### Static Assets
+
+This component includes client-side resources such as CSS stylesheets for visual presentation, JavaScript files for interactive elements (e.g., clipboard functionality, password preview), and fonts. These assets are served directly by the web server and are crucial for the user experience and visual design of the application.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `snappass.static` (1:1)
+
+
+
+
+
+### Internationalization/Translations
+
+This component manages multi-language support for the application. It provides the mechanisms and data (translation files) to display the user interface in different languages, enhancing accessibility and usability for a global audience.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `snappass.translations` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Application_Core.md
+++ b/.codeboarding/Application_Core.md
@@ -1,0 +1,143 @@
+```mermaid
+
+graph LR
+
+    Application_Core["Application Core"]
+
+    User_Interface_Templates["User Interface Templates"]
+
+    Static_Assets["Static Assets"]
+
+    Internationalization_I18n_["Internationalization (I18n)"]
+
+    Application_Core -- "renders" --> User_Interface_Templates
+
+    Application_Core -- "serves" --> Static_Assets
+
+    Application_Core -- "uses" --> Internationalization_I18n_
+
+    User_Interface_Templates -- "link to and utilize" --> Static_Assets
+
+    Internationalization_I18n_ -- "provides translated content to" --> User_Interface_Templates
+
+    click Application_Core href "https://github.com/pinterest/snappass/blob/master/.codeboarding//Application_Core.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `snappass` package does not contain any classes, which is unusual for a Python application. This suggests that the application's logic is primarily implemented using functions and module-level code, rather than an object-oriented approach with classes. This is common in smaller Flask applications where a more procedural style might be adopted. Given this, I will proceed with defining the components based on the file structure and the functional responsibilities identified in the initial analysis, focusing on modules and their interactions rather than class hierarchies.
+
+
+
+### Application Core [[Expand]](./Application_Core.md)
+
+This is the heart of the `snappass` application. It's responsible for initializing the Flask application, defining URL routes, handling request processing, managing cryptographic operations (encryption/decryption), and interacting with the Redis store for ephemeral secret management. It acts as the central orchestrator, directing incoming requests to the appropriate logic and rendering responses.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L355-L357" target="_blank" rel="noopener noreferrer">`snappass.main` (355:357)</a>
+
+
+
+
+
+### User Interface Templates
+
+This component consists of Jinja2 HTML templates that define the structure and presentation of the web pages. They are the "View" in the Model-View-Template (MVT) pattern, responsible for rendering data provided by the `Application Core` and capturing user input through forms.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `snappass.templates.base` (1:1000)
+
+- `snappass.templates.confirm` (1:1000)
+
+- `snappass.templates.password` (1:1000)
+
+- `snappass.templates.preview` (1:1000)
+
+- `snappass.templates.set_password` (1:1000)
+
+- `snappass.templates.expired` (1:1000)
+
+
+
+
+
+### Static Assets
+
+This component provides client-side resources such as CSS for styling, JavaScript for interactive elements (e.g., clipboard functionality, password preview), and fonts. These assets are served directly by the web server to the client's browser, enhancing the user experience.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `snappass.static.bootstrap` (1:1000)
+
+- `snappass.static.clipboardjs` (1:1000)
+
+- `snappass.static.fontawesome` (1:1000)
+
+- `snappass.static.jquery` (1:1000)
+
+- `snappass.static.snappass.css.custom` (1:1000)
+
+- `snappass.static.snappass.scripts.clipboard_button` (1:1000)
+
+- `snappass.static.snappass.scripts.preview` (1:1000)
+
+
+
+
+
+### Internationalization (I18n)
+
+This component manages multi-language support for the application. It includes message catalogs for various locales, allowing the user interface to be displayed in different languages based on user preferences.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `snappass.translations.messages` (1:1000)
+
+- `snappass.translations.en.LC_MESSAGES.messages_mo` (1:1000)
+
+- `snappass.translations.en.LC_MESSAGES.messages_po` (1:1000)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Shared_Utilities.md
+++ b/.codeboarding/Shared_Utilities.md
@@ -1,0 +1,199 @@
+```mermaid
+
+graph LR
+
+    Main_Application["Main Application"]
+
+    Secret_Management["Secret Management"]
+
+    Cryptographic_Services["Cryptographic Services"]
+
+    Shared_Utilities["Shared Utilities"]
+
+    User_Interface_Templates_["User Interface (Templates)"]
+
+    Static_Assets["Static Assets"]
+
+    Internationalization["Internationalization"]
+
+    Main_Application -- "uses" --> Secret_Management
+
+    Main_Application -- "uses" --> Cryptographic_Services
+
+    Main_Application -- "uses" --> Shared_Utilities
+
+    Main_Application -- "renders" --> User_Interface_Templates_
+
+    Main_Application -- "serves" --> Static_Assets
+
+    Main_Application -- "uses" --> Internationalization
+
+    User_Interface_Templates_ -- "links to" --> Static_Assets
+
+    User_Interface_Templates_ -- "receives content from" --> Internationalization
+
+    click Shared_Utilities href "https://github.com/pinterest/snappass/blob/master/.codeboarding//Shared_Utilities.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### Main Application
+
+The central orchestrator of the Flask application, handling routing, request processing, and integrating various functionalities. It manages the overall flow, dispatches requests to appropriate handlers, and coordinates interactions between other components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L355-L357" target="_blank" rel="noopener noreferrer">`snappass.main` (355:357)</a>
+
+
+
+
+
+### Secret Management
+
+Responsible for the secure storage, retrieval, and management of ephemeral secrets using Redis. This includes setting Time-To-Live (TTL) for secrets and handling their one-time retrieval.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L138-L150" target="_blank" rel="noopener noreferrer">`snappass.main:set_password` (138:150)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L154-L170" target="_blank" rel="noopener noreferrer">`snappass.main:get_password` (154:170)</a>
+
+
+
+
+
+### Cryptographic Services
+
+Provides functionalities for encrypting and decrypting secrets, ensuring data confidentiality during storage and transmission.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L74-L82" target="_blank" rel="noopener noreferrer">`snappass.main:encrypt` (74:82)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L85-L91" target="_blank" rel="noopener noreferrer">`snappass.main:decrypt` (85:91)</a>
+
+
+
+
+
+### Shared Utilities [[Expand]](./Shared_Utilities.md)
+
+A collection of common helper functions and utilities used across various parts of the application. This includes input validation, standardized error response formatting, dynamic URL generation, and token extraction, promoting code reusability and consistency.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L94-L103" target="_blank" rel="noopener noreferrer">`snappass.main:parse_token` (94:103)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L106-L114" target="_blank" rel="noopener noreferrer">`snappass.main:as_validation_problem` (106:114)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L117-L125" target="_blank" rel="noopener noreferrer">`snappass.main:as_not_found_problem` (117:125)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L128-L134" target="_blank" rel="noopener noreferrer">`snappass.main:as_problem_response` (128:134)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L179-L181" target="_blank" rel="noopener noreferrer">`snappass.main:empty` (179:181)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L184-L199" target="_blank" rel="noopener noreferrer">`snappass.main:clean_input` (184:199)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L202-L215" target="_blank" rel="noopener noreferrer">`snappass.main:set_base_url` (202:215)</a>
+
+
+
+
+
+### User Interface (Templates)
+
+Comprises Jinja2 HTML files that define the user interface, responsible for presenting data processed by the application to the user.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `snappass.templates` (1:2)
+
+
+
+
+
+### Static Assets
+
+Provides client-side resources such as CSS for styling, JavaScript for dynamic behaviors, and fonts, essential for the application's presentation and interactivity.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `snappass.static` (1:2)
+
+
+
+
+
+### Internationalization
+
+Manages multi-language support, enabling the application's user interface to be displayed in various languages.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `snappass.translations` (1:2)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Web_UI_Endpoints.md
+++ b/.codeboarding/Web_UI_Endpoints.md
@@ -1,0 +1,181 @@
+```mermaid
+
+graph LR
+
+    Web_UI_Endpoints["Web UI Endpoints"]
+
+    Main_Application_Logic["Main Application Logic"]
+
+    Password_Service_Storage["Password Service/Storage"]
+
+    Frontend_Assets["Frontend Assets"]
+
+    Templates["Templates"]
+
+    Internationalization_Translations["Internationalization/Translations"]
+
+    Web_UI_Endpoints -- "Interacts with" --> Main_Application_Logic
+
+    Web_UI_Endpoints -- "Renders" --> Templates
+
+    Web_UI_Endpoints -- "Utilizes" --> Internationalization_Translations
+
+    Main_Application_Logic -- "Interacts with" --> Password_Service_Storage
+
+    Templates -- "Utilizes" --> Frontend_Assets
+
+    Web_UI_Endpoints -- "Serves" --> Frontend_Assets
+
+    click Web_UI_Endpoints href "https://github.com/pinterest/snappass/blob/master/.codeboarding//Web_UI_Endpoints.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### Web UI Endpoints [[Expand]](./Web_UI_Endpoints.md)
+
+Manages the user-facing web interface and API endpoints, handling HTTP requests for various HTML pages (e.g., set password form, preview, show password) and API interactions. It processes form submissions, orchestrates interactions with the `Main Application Logic`, and dynamically renders `Templates` to display information to the user or return JSON responses for API calls. It acts as the "Controller" in the MVT pattern.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L219-L220" target="_blank" rel="noopener noreferrer">`snappass.main.index` (219:220)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L210-L214" target="_blank" rel="noopener noreferrer">`snappass.main.set_password_form` (210:214)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L224-L238" target="_blank" rel="noopener noreferrer">`snappass.main.handle_password` (224:238)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L250-L286" target="_blank" rel="noopener noreferrer">`snappass.main.api_set_password` (250:286)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L290-L306" target="_blank" rel="noopener noreferrer">`snappass.main.api_get_password` (290:306)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L310-L326" target="_blank" rel="noopener noreferrer">`snappass.main.api_check_password` (310:326)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L330-L335" target="_blank" rel="noopener noreferrer">`snappass.main.preview_password` (330:335)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L339-L345" target="_blank" rel="noopener noreferrer">`snappass.main.show_password` (339:345)</a>
+
+
+
+
+
+### Main Application Logic
+
+Encapsulates the core business logic of the application, including password encryption, decryption, token parsing, and the overall flow of creating, retrieving, and checking password existence. It acts as an intermediary, coordinating between the `Web UI Endpoints` and the `Password Service/Storage`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L74-L82" target="_blank" rel="noopener noreferrer">`snappass.main.encrypt` (74:82)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L85-L91" target="_blank" rel="noopener noreferrer">`snappass.main.decrypt` (85:91)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L94-L103" target="_blank" rel="noopener noreferrer">`snappass.main.parse_token` (94:103)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L138-L150" target="_blank" rel="noopener noreferrer">`snappass.main.set_password` (138:150)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L154-L170" target="_blank" rel="noopener noreferrer">`snappass.main.get_password` (154:170)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L174-L176" target="_blank" rel="noopener noreferrer">`snappass.main.password_exists` (174:176)</a>
+
+
+
+
+
+### Password Service/Storage
+
+Provides an interface for securely storing and retrieving ephemeral passwords using Redis. It abstracts the underlying storage mechanism and handles operations like setting, getting, and checking the existence of passwords, ensuring data integrity and security. It also includes a mechanism to check Redis connectivity.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L39-L50" target="_blank" rel="noopener noreferrer">`snappass.main.redis_client` (39:50)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L138-L150" target="_blank" rel="noopener noreferrer">`snappass.main.set_password` (138:150)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L154-L170" target="_blank" rel="noopener noreferrer">`snappass.main.get_password` (154:170)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L174-L176" target="_blank" rel="noopener noreferrer">`snappass.main.password_exists` (174:176)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L58-L71" target="_blank" rel="noopener noreferrer">`snappass.main.check_redis_alive` (58:71)</a>
+
+
+
+
+
+### Frontend Assets
+
+Contains all static files (CSS, JavaScript, images, fonts) required for the client-side rendering and interactivity of the web interface. These assets are served directly to the user's browser to build the visual and interactive elements of the UI.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Templates
+
+Consists of Jinja2 HTML templates that define the structure and layout of the web pages displayed to the user. These templates are dynamically populated with data by the `Web UI Endpoints` and `Main Application Logic` to render the final HTML.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Internationalization/Translations
+
+Manages the localization of the application's text content, providing support for multiple languages. It allows the application to display messages and labels in the user's preferred language, enhancing accessibility. This component leverages Flask-Babel for translation services.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L36-L36" target="_blank" rel="noopener noreferrer">`snappass.main.babel` (36:36)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L31-L32" target="_blank" rel="noopener noreferrer">`snappass.main.get_locale` (31:32)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,237 @@
+```mermaid
+
+graph LR
+
+    Application_Core["Application Core"]
+
+    API_Endpoints["API Endpoints"]
+
+    Web_UI_Endpoints["Web UI Endpoints"]
+
+    Password_Service["Password Service"]
+
+    Cryptography_Module["Cryptography Module"]
+
+    Shared_Utilities["Shared Utilities"]
+
+    Frontend_Assets["Frontend Assets"]
+
+    Application_Core -- "Orchestrates" --> API_Endpoints
+
+    Application_Core -- "Orchestrates" --> Web_UI_Endpoints
+
+    Application_Core -- "Utilizes" --> Shared_Utilities
+
+    API_Endpoints -- "Invokes" --> Password_Service
+
+    API_Endpoints -- "Utilizes" --> Shared_Utilities
+
+    Web_UI_Endpoints -- "Invokes" --> Password_Service
+
+    Web_UI_Endpoints -- "Renders" --> Frontend_Assets
+
+    Web_UI_Endpoints -- "Utilizes" --> Shared_Utilities
+
+    Password_Service -- "Utilizes" --> Cryptography_Module
+
+    Password_Service -- "Utilizes" --> Shared_Utilities
+
+    click Application_Core href "https://github.com/pinterest/snappass/blob/master/.codeboarding//Application_Core.md" "Details"
+
+    click API_Endpoints href "https://github.com/pinterest/snappass/blob/master/.codeboarding//API_Endpoints.md" "Details"
+
+    click Web_UI_Endpoints href "https://github.com/pinterest/snappass/blob/master/.codeboarding//Web_UI_Endpoints.md" "Details"
+
+    click Shared_Utilities href "https://github.com/pinterest/snappass/blob/master/.codeboarding//Shared_Utilities.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `snappass` project is a Flask-based web application designed for secure, ephemeral secret sharing. Users can set a password or secret via a web interface or API, which is then encrypted and stored temporarily. A unique URL is generated for retrieval. Upon the first access, the secret is decrypted and displayed, after which it is immediately and permanently deleted, ensuring its ephemeral nature. The application provides both a user-friendly web interface and a programmatic API for interaction.
+
+
+
+### Application Core [[Expand]](./Application_Core.md)
+
+The central module responsible for initializing the Flask application, configuring global settings, and defining the main URL routes. It acts as the primary orchestrator, directing incoming requests to the appropriate handling layers.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L355-L357" target="_blank" rel="noopener noreferrer">`snappass.main` (355:357)</a>
+
+
+
+
+
+### API Endpoints [[Expand]](./API_Endpoints.md)
+
+Handles all RESTful API requests for setting, checking, and retrieving ephemeral passwords. It processes JSON payloads, interacts with the `Password Service` for business logic, and returns structured JSON responses, including error handling.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L242-L251" target="_blank" rel="noopener noreferrer">`snappass.main:api_handle_password` (242:251)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L255-L298" target="_blank" rel="noopener noreferrer">`snappass.main:api_v2_set_password` (255:298)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L302-L309" target="_blank" rel="noopener noreferrer">`snappass.main:api_v2_check_password` (302:309)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L313-L326" target="_blank" rel="noopener noreferrer">`snappass.main:api_v2_retrieve_password` (313:326)</a>
+
+
+
+
+
+### Web UI Endpoints [[Expand]](./Web_UI_Endpoints.md)
+
+Manages the user-facing web interface, handling requests for HTML pages (e.g., set password form, preview, show password). It processes form submissions, interacts with the `Password Service`, and dynamically renders `Frontend Assets` to display information to the user.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L224-L238" target="_blank" rel="noopener noreferrer">`snappass.main:handle_password` (224:238)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L330-L335" target="_blank" rel="noopener noreferrer">`snappass.main:preview_password` (330:335)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L339-L345" target="_blank" rel="noopener noreferrer">`snappass.main:show_password` (339:345)</a>
+
+
+
+
+
+### Password Service
+
+Encapsulates the core business logic for managing ephemeral passwords. It handles the creation (storage), retrieval, and existence checks of passwords, acting as the intermediary between the endpoint layers and the underlying data storage and cryptographic operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L138-L150" target="_blank" rel="noopener noreferrer">`snappass.main:set_password` (138:150)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L154-L170" target="_blank" rel="noopener noreferrer">`snappass.main:get_password` (154:170)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L174-L176" target="_blank" rel="noopener noreferrer">`snappass.main:password_exists` (174:176)</a>
+
+
+
+
+
+### Cryptography Module
+
+Provides secure cryptographic operations, specifically encryption and decryption, to protect sensitive password data. It ensures data confidentiality during storage and transmission, making the secrets unreadable without proper decryption.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L74-L82" target="_blank" rel="noopener noreferrer">`snappass.main:encrypt` (74:82)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L85-L91" target="_blank" rel="noopener noreferrer">`snappass.main:decrypt` (85:91)</a>
+
+
+
+
+
+### Shared Utilities [[Expand]](./Shared_Utilities.md)
+
+A collection of common helper functions and utilities used across various parts of the application. This includes input validation, standardized error response formatting, dynamic URL generation, and token extraction, promoting code reusability and consistency.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L184-L199" target="_blank" rel="noopener noreferrer">`snappass.main:clean_input` (184:199)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L179-L181" target="_blank" rel="noopener noreferrer">`snappass.main:empty` (179:181)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L106-L114" target="_blank" rel="noopener noreferrer">`snappass.main:as_validation_problem` (106:114)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L117-L125" target="_blank" rel="noopener noreferrer">`snappass.main:as_not_found_problem` (117:125)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L128-L134" target="_blank" rel="noopener noreferrer">`snappass.main:as_problem_response` (128:134)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L202-L215" target="_blank" rel="noopener noreferrer">`snappass.main:set_base_url` (202:215)</a>
+
+- <a href="https://github.com/pinterest/snappass/blob/master/snappass/main.py#L94-L103" target="_blank" rel="noopener noreferrer">`snappass.main:parse_token` (94:103)</a>
+
+
+
+
+
+### Frontend Assets
+
+Comprises the presentation layer resources for the web application. This includes Jinja2 HTML templates for page structure and content, along with static files like CSS stylesheets for styling, JavaScript files for interactivity, and fonts/images for visual elements.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `templates/index.html` (1:1)
+
+- `templates/password.html` (1:1)
+
+- `templates/preview.html` (1:1)
+
+- `templates/show.html` (1:1)
+
+- `templates/problem.html` (1:1)
+
+- `static/css/style.css` (1:1)
+
+- `static/js/script.js` (1:1)
+
+- `static/fonts/` (1:1)
+
+- `static/img/` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
In this PR, I am adding a diagram visualizaiton for the snappass project.
It seems like the README.md is your main documentation point, so I can link the visualization there if you like it!

You can see how the diagrams in this change render here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/snappass/on_boarding.md

The goal of these documents is to help people get up to speed quickly with the git-stacktrace codebase. The diagrams are designed to give immediate overview of the codebase and allow you to dig deeper into each component of interest. The whole visualization is generated so it is easy to keep up-to-date. The generation is done via StaticAnalysis and LLMs - that's why for now it covers the python part of the source code.

Would love to connect and discuss how can we help the people who work and contributo to pinterest's codebase. We are curious to hear how do you keep docs up-to-date so that people can get up-to-speed to different projects within the company!

Any feedback is more than welcome!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.

Further I we also have a free github action to keep the whole thing up-to-date with new commits.