### PR TITLE
Fix Host header injection in generated password links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,10 @@ need to change this.
 
 ``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
+``APP_BASE_URL``: (optional, recommended) Canonical absolute base URL used for generated links and API problem URLs. Example: ``https://snappass.example.com``
+
+``TRUSTED_HOSTS``: (optional) Comma-separated allowlist of hostnames accepted from inbound Host headers when ``APP_BASE_URL`` and ``HOST_OVERRIDE`` are not set. Defaults to ``localhost,127.0.0.1,::1``.
+
 ``SNAPPASS_BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
 
 ``SNAPPASS_PORT``: (optional) Used to override the default port of 5000 Example: ``6000``

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,15 @@ need to change this.
 
 ``TRUSTED_HOSTS``: (optional) Comma-separated allowlist of hostnames accepted from inbound Host headers when ``APP_BASE_URL`` and ``HOST_OVERRIDE`` are not set. Defaults to ``localhost,127.0.0.1,::1``.
 
+Host Header Security
+^^^^^^^^^^^^^^^^^^^^
+
+SnapPass generates security-sensitive links (for password retrieval). To prevent host header injection in generated links:
+
+- Prefer setting ``APP_BASE_URL`` in production.
+- If ``APP_BASE_URL`` is not set, configure ``TRUSTED_HOSTS`` to the exact hostnames you expect.
+- Requests with an untrusted ``Host`` header are rejected with ``400 Bad Request`` when SnapPass must derive the base URL from the request.
+
 ``SNAPPASS_BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
 
 ``SNAPPASS_PORT``: (optional) Used to override the default port of 5000 Example: ``6000``

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -10,6 +10,7 @@ from redis.exceptions import ConnectionError
 from urllib.parse import quote_plus
 from urllib.parse import unquote_plus
 from urllib.parse import urljoin
+from urllib.parse import urlsplit
 from distutils.util import strtobool
 # _ is required to get the Jinja templates translated
 from flask_babel import Babel, _  # noqa: F401
@@ -17,6 +18,8 @@ from flask_babel import Babel, _  # noqa: F401
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
 URL_PREFIX = os.environ.get('URL_PREFIX', None)
 HOST_OVERRIDE = os.environ.get('HOST_OVERRIDE', None)
+APP_BASE_URL = os.environ.get('APP_BASE_URL', None)
+TRUSTED_HOSTS = os.environ.get('TRUSTED_HOSTS', None)
 TOKEN_SEPARATOR = '~'
 
 # Initialize Flask Application
@@ -54,6 +57,29 @@ TIME_CONVERSION = {'two weeks': 1209600, 'week': 604800, 'day': 86400,
                    'hour': 3600}
 DEFAULT_API_TTL = 1209600
 MAX_TTL = DEFAULT_API_TTL
+
+
+def _normalize_base_url(base_url):
+    return base_url.rstrip('/') + '/'
+
+
+def _get_trusted_hosts():
+    if TRUSTED_HOSTS:
+        return {
+            host.strip().lower().rstrip('.')
+            for host in TRUSTED_HOSTS.split(',')
+            if host.strip()
+        }
+    return {'localhost', '127.0.0.1', '::1'}
+
+
+def _request_has_trusted_host(req):
+    parsed = urlsplit('//' + req.host)
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+    normalized_hostname = hostname.lower().rstrip('.')
+    return normalized_hostname in _get_trusted_hosts()
 
 
 def check_redis_alive(fn):
@@ -201,16 +227,24 @@ def clean_input():
 
 
 def set_base_url(req):
-    if NO_SSL:
-        if HOST_OVERRIDE:
-            base_url = f'http://{HOST_OVERRIDE}/'
-        else:
-            base_url = req.url_root
+    if APP_BASE_URL:
+        base_url = _normalize_base_url(APP_BASE_URL)
     else:
-        if HOST_OVERRIDE:
-            base_url = f'https://{HOST_OVERRIDE}/'
+        if NO_SSL:
+            if HOST_OVERRIDE:
+                base_url = f'http://{HOST_OVERRIDE}/'
+            else:
+                if not _request_has_trusted_host(req):
+                    abort(400)
+                base_url = req.url_root
         else:
-            base_url = req.url_root.replace("http://", "https://")
+            if HOST_OVERRIDE:
+                base_url = f'https://{HOST_OVERRIDE}/'
+            else:
+                if not _request_has_trusted_host(req):
+                    abort(400)
+                base_url = req.url_root.replace("http://", "https://")
+    base_url = _normalize_base_url(base_url)
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
     return base_url

--- a/tests.py
+++ b/tests.py
@@ -106,6 +106,18 @@ class SnapPassRoutesTestCase(TestCase):
     def setUp(self):
         snappass.app.config['TESTING'] = True
         self.app = snappass.app.test_client()
+        self.original_url_prefix = snappass.URL_PREFIX
+        self.original_host_override = snappass.HOST_OVERRIDE
+        self.original_app_base_url = snappass.APP_BASE_URL
+        self.original_trusted_hosts = snappass.TRUSTED_HOSTS
+        self.original_no_ssl = snappass.NO_SSL
+
+    def tearDown(self):
+        snappass.URL_PREFIX = self.original_url_prefix
+        snappass.HOST_OVERRIDE = self.original_host_override
+        snappass.APP_BASE_URL = self.original_app_base_url
+        snappass.TRUSTED_HOSTS = self.original_trusted_hosts
+        snappass.NO_SSL = self.original_no_ssl
 
     def test_health_check(self):
         response = self.app.get('/_/_/health')
@@ -201,6 +213,27 @@ class SnapPassRoutesTestCase(TestCase):
 
             frozen_time.move_to("2020-05-22 12:00:00")
             self.assertIsNone(snappass.get_password(key))
+
+    def test_rejects_untrusted_host_header(self):
+        rv = self.app.post(
+            '/api/set_password/',
+            headers={'Host': 'evil.com', 'Accept': 'application/json'},
+            json={'password': 'my secret', 'ttl': '1209600'},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+
+    def test_uses_app_base_url_with_untrusted_host_header(self):
+        snappass.APP_BASE_URL = 'https://snappass.example.org'
+        rv = self.app.post(
+            '/api/set_password/',
+            headers={'Host': 'evil.com', 'Accept': 'application/json'},
+            json={'password': 'my secret', 'ttl': '1209600'},
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        json_content = rv.get_json()
+        self.assertTrue(json_content['link'].startswith('https://snappass.example.org/'))
 
     def test_set_password_api_v2(self):
         with freeze_time("2020-05-08 12:00:00") as frozen_time:


### PR DESCRIPTION
## Summary
- stop trusting inbound Host headers for security-sensitive link generation by adding trusted-host validation when deriving base URLs
- support a canonical `APP_BASE_URL` override and document `TRUSTED_HOSTS` for safer deployments
- add regression tests to confirm untrusted hosts are rejected and canonical URL override behavior remains stable

## Test plan
- [ ] `python tests.py`
- [ ] confirm `/api/set_password/` returns `400` when sent with an untrusted `Host` header and no override configured
- [ ] confirm generated links use `APP_BASE_URL` when configured