### PR TITLE
Fix Host header injection in generated password links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,10 @@ need to change this.
 
 ``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
 
+``APP_BASE_URL``: (optional, recommended) Canonical absolute base URL used for generated links and API problem URLs. Example: ``https://snappass.example.com``
+
+``TRUSTED_HOSTS``: (optional) Comma-separated allowlist of hostnames accepted from inbound Host headers when ``APP_BASE_URL`` and ``HOST_OVERRIDE`` are not set. Defaults to ``localhost,127.0.0.1,::1``.
+
 ``SNAPPASS_BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
 
 ``SNAPPASS_PORT``: (optional) Used to override the default port of 5000 Example: ``6000``

--- a/README.rst
+++ b/README.rst
@@ -100,18 +100,18 @@ need to change this.
 
 ``TRUSTED_HOSTS``: (optional) Comma-separated allowlist of hostnames accepted from inbound Host headers when ``APP_BASE_URL`` and ``HOST_OVERRIDE`` are not set. Defaults to ``localhost,127.0.0.1,::1``.
 
+``SNAPPASS_BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
+
+``SNAPPASS_PORT``: (optional) Used to override the default port of 5000 Example: ``6000``
+
 Host Header Security
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 SnapPass generates security-sensitive links (for password retrieval). To prevent host header injection in generated links:
 
 - Prefer setting ``APP_BASE_URL`` in production.
 - If ``APP_BASE_URL`` is not set, configure ``TRUSTED_HOSTS`` to the exact hostnames you expect.
 - Requests with an untrusted ``Host`` header are rejected with ``400 Bad Request`` when SnapPass must derive the base URL from the request.
-
-``SNAPPASS_BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
-
-``SNAPPASS_PORT``: (optional) Used to override the default port of 5000 Example: ``6000``
 
 APIs
 ----

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,15 @@ need to change this.
 
 ``TRUSTED_HOSTS``: (optional) Comma-separated allowlist of hostnames accepted from inbound Host headers when ``APP_BASE_URL`` and ``HOST_OVERRIDE`` are not set. Defaults to ``localhost,127.0.0.1,::1``.
 
+Host Header Security
+^^^^^^^^^^^^^^^^^^^^
+
+SnapPass generates security-sensitive links (for password retrieval). To prevent host header injection in generated links:
+
+- Prefer setting ``APP_BASE_URL`` in production.
+- If ``APP_BASE_URL`` is not set, configure ``TRUSTED_HOSTS`` to the exact hostnames you expect.
+- Requests with an untrusted ``Host`` header are rejected with ``400 Bad Request`` when SnapPass must derive the base URL from the request.
+
 ``SNAPPASS_BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
 
 ``SNAPPASS_PORT``: (optional) Used to override the default port of 5000 Example: ``6000``

--- a/README.rst
+++ b/README.rst
@@ -94,11 +94,7 @@ need to change this.
 
 ``REDIS_PREFIX``: (optional, defaults to ``"snappass"``) prefix used on redis keys to prevent collisions with other potential clients
 
-``HOST_OVERRIDE``: (optional) Used to override the base URL if the app is unaware. Useful when running behind reverse proxies like an identity-aware SSO. Example: ``sub.domain.com``
-
-``APP_BASE_URL``: (optional, recommended) Canonical absolute base URL used for generated links and API problem URLs. Example: ``https://snappass.example.com``
-
-``TRUSTED_HOSTS``: (optional) Comma-separated allowlist of hostnames accepted from inbound Host headers when ``APP_BASE_URL`` and ``HOST_OVERRIDE`` are not set. Defaults to ``localhost,127.0.0.1,::1``.
+``HOST_OVERRIDE``: (optional, recommended in production) Canonical hostname used to build the base URL for generated links. Useful when running behind reverse proxies like an identity-aware SSO, and prevents host header injection (see below). Example: ``sub.domain.com``
 
 ``SNAPPASS_BIND_ADDRESS``: (optional) Used to override the default bind address of 0.0.0.0 for flask app Example: ``127.0.0.1``
 
@@ -107,11 +103,10 @@ need to change this.
 Host Header Security
 --------------------
 
-SnapPass generates security-sensitive links (for password retrieval). To prevent host header injection in generated links:
+SnapPass generates security-sensitive links (for password retrieval). When ``HOST_OVERRIDE`` is not set, the base URL of those links is derived from the request's ``Host`` header, which a client can spoof.
 
-- Prefer setting ``APP_BASE_URL`` in production.
-- If ``APP_BASE_URL`` is not set, configure ``TRUSTED_HOSTS`` to the exact hostnames you expect.
-- Requests with an untrusted ``Host`` header are rejected with ``400 Bad Request`` when SnapPass must derive the base URL from the request.
+- Set ``HOST_OVERRIDE`` to your canonical hostname in production. It is then used for every generated link and the inbound ``Host`` header is ignored.
+- If ``HOST_OVERRIDE`` is not set, SnapPass only derives the base URL from loopback hosts (``localhost``, ``127.0.0.1``, ``::1``); requests with any other ``Host`` header are rejected with ``400 Bad Request``.
 
 APIs
 ----

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -18,8 +18,6 @@ from flask_babel import Babel, _  # noqa: F401
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
 URL_PREFIX = os.environ.get('URL_PREFIX', None)
 HOST_OVERRIDE = os.environ.get('HOST_OVERRIDE', None)
-APP_BASE_URL = os.environ.get('APP_BASE_URL', None)
-TRUSTED_HOSTS = os.environ.get('TRUSTED_HOSTS', None)
 TOKEN_SEPARATOR = '~'
 
 # Initialize Flask Application
@@ -59,27 +57,17 @@ DEFAULT_API_TTL = 1209600
 MAX_TTL = DEFAULT_API_TTL
 
 
-def _normalize_base_url(base_url):
-    return base_url.rstrip('/') + '/'
-
-
-def _get_trusted_hosts():
-    if TRUSTED_HOSTS:
-        return {
-            host.strip().lower().rstrip('.')
-            for host in TRUSTED_HOSTS.split(',')
-            if host.strip()
-        }
-    return {'localhost', '127.0.0.1', '::1'}
-
-
 def _request_has_trusted_host(req):
+    # When HOST_OVERRIDE is not configured the base URL is derived from the
+    # request's Host header, which a client can spoof. Only loopback hosts are
+    # trusted for that fallback (local/dev use); production should set
+    # HOST_OVERRIDE to its canonical hostname.
     parsed = urlsplit('//' + req.host)
     hostname = parsed.hostname
     if not hostname:
         return False
     normalized_hostname = hostname.lower().rstrip('.')
-    return normalized_hostname in _get_trusted_hosts()
+    return normalized_hostname in {'localhost', '127.0.0.1', '::1'}
 
 
 def check_redis_alive(fn):
@@ -227,24 +215,15 @@ def clean_input():
 
 
 def set_base_url(req):
-    if APP_BASE_URL:
-        base_url = _normalize_base_url(APP_BASE_URL)
+    scheme = 'http' if NO_SSL else 'https'
+    if HOST_OVERRIDE:
+        base_url = f'{scheme}://{HOST_OVERRIDE}/'
     else:
-        if NO_SSL:
-            if HOST_OVERRIDE:
-                base_url = f'http://{HOST_OVERRIDE}/'
-            else:
-                if not _request_has_trusted_host(req):
-                    abort(400)
-                base_url = req.url_root
-        else:
-            if HOST_OVERRIDE:
-                base_url = f'https://{HOST_OVERRIDE}/'
-            else:
-                if not _request_has_trusted_host(req):
-                    abort(400)
-                base_url = req.url_root.replace("http://", "https://")
-    base_url = _normalize_base_url(base_url)
+        if not _request_has_trusted_host(req):
+            abort(400)
+        base_url = req.url_root
+        if not NO_SSL:
+            base_url = base_url.replace("http://", "https://")
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
     return base_url

--- a/snappass/main.py
+++ b/snappass/main.py
@@ -10,6 +10,7 @@ from redis.exceptions import ConnectionError
 from urllib.parse import quote_plus
 from urllib.parse import unquote_plus
 from urllib.parse import urljoin
+from urllib.parse import urlsplit
 from distutils.util import strtobool
 # _ is required to get the Jinja templates translated
 from flask_babel import Babel, _  # noqa: F401
@@ -17,6 +18,8 @@ from flask_babel import Babel, _  # noqa: F401
 NO_SSL = bool(strtobool(os.environ.get('NO_SSL', 'False')))
 URL_PREFIX = os.environ.get('URL_PREFIX', None)
 HOST_OVERRIDE = os.environ.get('HOST_OVERRIDE', None)
+APP_BASE_URL = os.environ.get('APP_BASE_URL', None)
+TRUSTED_HOSTS = os.environ.get('TRUSTED_HOSTS', None)
 TOKEN_SEPARATOR = '~'
 
 # Initialize Flask Application
@@ -54,6 +57,29 @@ TIME_CONVERSION = {'two weeks': 1209600, 'week': 604800, 'day': 86400,
                    'hour': 3600}
 DEFAULT_API_TTL = 1209600
 MAX_TTL = DEFAULT_API_TTL
+
+
+def _normalize_base_url(base_url):
+    return base_url.rstrip('/') + '/'
+
+
+def _get_trusted_hosts():
+    if TRUSTED_HOSTS:
+        return {
+            host.strip().lower().rstrip('.')
+            for host in TRUSTED_HOSTS.split(',')
+            if host.strip()
+        }
+    return {'localhost', '127.0.0.1', '::1'}
+
+
+def _request_has_trusted_host(req):
+    parsed = urlsplit('//' + req.host)
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+    normalized_hostname = hostname.lower().rstrip('.')
+    return normalized_hostname in _get_trusted_hosts()
 
 
 def check_redis_alive(fn):
@@ -201,16 +227,24 @@ def clean_input():
 
 
 def set_base_url(req):
-    if NO_SSL:
-        if HOST_OVERRIDE:
-            base_url = f'http://{HOST_OVERRIDE}/'
-        else:
-            base_url = req.url_root
+    if APP_BASE_URL:
+        base_url = _normalize_base_url(APP_BASE_URL)
     else:
-        if HOST_OVERRIDE:
-            base_url = f'https://{HOST_OVERRIDE}/'
+        if NO_SSL:
+            if HOST_OVERRIDE:
+                base_url = f'http://{HOST_OVERRIDE}/'
+            else:
+                if not _request_has_trusted_host(req):
+                    abort(400)
+                base_url = req.url_root
         else:
-            base_url = req.url_root.replace("http://", "https://")
+            if HOST_OVERRIDE:
+                base_url = f'https://{HOST_OVERRIDE}/'
+            else:
+                if not _request_has_trusted_host(req):
+                    abort(400)
+                base_url = req.url_root.replace("http://", "https://")
+    base_url = _normalize_base_url(base_url)
     if URL_PREFIX:
         base_url = base_url + URL_PREFIX.strip("/") + "/"
     return base_url

--- a/tests.py
+++ b/tests.py
@@ -107,14 +107,14 @@ class SnapPassRoutesTestCase(TestCase):
         snappass.app.config['TESTING'] = True
         self.app = snappass.app.test_client()
         self.original_url_prefix = snappass.URL_PREFIX
-        self.original_app_base_url = snappass.APP_BASE_URL
+        self.original_host_override = snappass.HOST_OVERRIDE
 
     def tearDown(self):
         # Restore module-level config mutated by tests so it does not leak
-        # between test cases (URL_PREFIX by test_url_prefix, APP_BASE_URL by
-        # test_uses_app_base_url_with_untrusted_host_header).
+        # between test cases (URL_PREFIX by test_url_prefix, HOST_OVERRIDE by
+        # test_uses_host_override_with_untrusted_host_header).
         snappass.URL_PREFIX = self.original_url_prefix
-        snappass.APP_BASE_URL = self.original_app_base_url
+        snappass.HOST_OVERRIDE = self.original_host_override
 
     def test_health_check(self):
         response = self.app.get('/_/_/health')
@@ -220,11 +220,11 @@ class SnapPassRoutesTestCase(TestCase):
 
         self.assertEqual(rv.status_code, 400)
 
-    def test_uses_app_base_url_with_untrusted_host_header(self):
-        # When APP_BASE_URL is configured, the inbound Host header is never
+    def test_uses_host_override_with_untrusted_host_header(self):
+        # When HOST_OVERRIDE is configured, the inbound Host header is never
         # used to derive the base URL, so an untrusted host is harmless: the
-        # request succeeds (200) and the generated link uses APP_BASE_URL.
-        snappass.APP_BASE_URL = 'https://snappass.example.org'
+        # request succeeds (200) and the generated link uses HOST_OVERRIDE.
+        snappass.HOST_OVERRIDE = 'snappass.example.org'
         rv = self.app.post(
             '/api/set_password/',
             headers={'Host': 'evil.com', 'Accept': 'application/json'},

--- a/tests.py
+++ b/tests.py
@@ -106,6 +106,18 @@ class SnapPassRoutesTestCase(TestCase):
     def setUp(self):
         snappass.app.config['TESTING'] = True
         self.app = snappass.app.test_client()
+        self.original_url_prefix = snappass.URL_PREFIX
+        self.original_host_override = snappass.HOST_OVERRIDE
+        self.original_app_base_url = snappass.APP_BASE_URL
+        self.original_trusted_hosts = snappass.TRUSTED_HOSTS
+        self.original_no_ssl = snappass.NO_SSL
+
+    def tearDown(self):
+        snappass.URL_PREFIX = self.original_url_prefix
+        snappass.HOST_OVERRIDE = self.original_host_override
+        snappass.APP_BASE_URL = self.original_app_base_url
+        snappass.TRUSTED_HOSTS = self.original_trusted_hosts
+        snappass.NO_SSL = self.original_no_ssl
 
     def test_health_check(self):
         response = self.app.get('/_/_/health')
@@ -201,6 +213,27 @@ class SnapPassRoutesTestCase(TestCase):
 
             frozen_time.move_to("2020-05-22 12:00:00")
             self.assertIsNone(snappass.get_password(key))
+
+    def test_rejects_untrusted_host_header(self):
+        rv = self.app.post(
+            '/api/set_password/',
+            headers={'Host': 'evil.com', 'Accept': 'application/json'},
+            json={'password': 'my secret', 'ttl': '1209600'},
+        )
+
+        self.assertEqual(rv.status_code, 400)
+
+    def test_uses_app_base_url_with_untrusted_host_header(self):
+        snappass.APP_BASE_URL = 'https://snappass.example.org'
+        rv = self.app.post(
+            '/api/set_password/',
+            headers={'Host': 'evil.com', 'Accept': 'application/json'},
+            json={'password': 'my secret', 'ttl': '1209600'},
+        )
+
+        self.assertEqual(rv.status_code, 200)
+        json_content = rv.get_json()
+        self.assertTrue(json_content['link'].startswith('https://snappass.example.org/'))
 
     def test_set_password_api_v2(self):
         with freeze_time("2020-05-08 12:00:00") as frozen_time:

--- a/tests.py
+++ b/tests.py
@@ -107,17 +107,14 @@ class SnapPassRoutesTestCase(TestCase):
         snappass.app.config['TESTING'] = True
         self.app = snappass.app.test_client()
         self.original_url_prefix = snappass.URL_PREFIX
-        self.original_host_override = snappass.HOST_OVERRIDE
         self.original_app_base_url = snappass.APP_BASE_URL
-        self.original_trusted_hosts = snappass.TRUSTED_HOSTS
-        self.original_no_ssl = snappass.NO_SSL
 
     def tearDown(self):
+        # Restore module-level config mutated by tests so it does not leak
+        # between test cases (URL_PREFIX by test_url_prefix, APP_BASE_URL by
+        # test_uses_app_base_url_with_untrusted_host_header).
         snappass.URL_PREFIX = self.original_url_prefix
-        snappass.HOST_OVERRIDE = self.original_host_override
         snappass.APP_BASE_URL = self.original_app_base_url
-        snappass.TRUSTED_HOSTS = self.original_trusted_hosts
-        snappass.NO_SSL = self.original_no_ssl
 
     def test_health_check(self):
         response = self.app.get('/_/_/health')
@@ -224,6 +221,9 @@ class SnapPassRoutesTestCase(TestCase):
         self.assertEqual(rv.status_code, 400)
 
     def test_uses_app_base_url_with_untrusted_host_header(self):
+        # When APP_BASE_URL is configured, the inbound Host header is never
+        # used to derive the base URL, so an untrusted host is harmless: the
+        # request succeeds (200) and the generated link uses APP_BASE_URL.
         snappass.APP_BASE_URL = 'https://snappass.example.org'
         rv = self.app.post(
             '/api/set_password/',


### PR DESCRIPTION
## Summary
- stop trusting inbound `Host` headers for security-sensitive link generation: when `HOST_OVERRIDE` is not set, only loopback hosts are trusted to derive the base URL and any other `Host` header is rejected with `400`
- rely on the existing `HOST_OVERRIDE` as the single canonical-host parameter (no new env vars), and document it as the recommended way to prevent host-header injection in production
- add regression tests covering untrusted-host rejection and the `HOST_OVERRIDE` override path

Incorporates review feedback from #448 (now closed): dropped the originally-proposed `APP_BASE_URL`/`TRUSTED_HOSTS` parameters in favor of reusing `HOST_OVERRIDE`.

## Test plan
- [x] `MOCK_REDIS=1 python tests.py` — all 28 tests pass
- [x] `/api/set_password/` returns `400` with an untrusted `Host` header and no `HOST_OVERRIDE` configured
- [x] generated links use `HOST_OVERRIDE` when configured, ignoring the inbound `Host` header